### PR TITLE
feat: scaffold Havok physics backend package

### DIFF
--- a/packages/physics-havok/README.md
+++ b/packages/physics-havok/README.md
@@ -1,0 +1,34 @@
+## Installation
+
+To install, use:
+
+```sh
+npm install @galacean/engine-physics-havok
+```
+
+This will allow you to import the Havok physics backend using:
+
+```javascript
+import * as PHYSICS_HAVOK from "@galacean/engine-physics-havok";
+```
+
+or individual classes using:
+
+```javascript
+import { HavokPhysics } from "@galacean/engine-physics-havok";
+```
+
+## Usage
+
+```typescript
+// Create engine by passing in the HTMLCanvasElement id and adjust canvas size
+const engine = await WebGLEngine.create({ canvas: "canvas-id" });
+
+// Initialize physics manager with HavokPhysics.
+engine.physicsManager.initialize(HavokPhysics);
+
+......
+
+// Run engine.
+engine.run();
+```

--- a/packages/physics-havok/package.json
+++ b/packages/physics-havok/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@galacean/engine-physics-havok",
+  "version": "1.6.5",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "repository": {
+    "url": "https://github.com/galacean/engine.git"
+  },
+  "license": "MIT",
+  "main": "dist/main.js",
+  "module": "dist/module.js",
+  "debug": "src/index.ts",
+  "browser": "dist/browser.js",
+  "types": "types/index.d.ts",
+  "scripts": {
+    "b:types": "tsc"
+  },
+  "umd": {
+    "name": "Galacean.PhysicsHavok",
+    "globals": {
+      "@galacean/engine": "Galacean"
+    }
+  },
+  "files": [
+    "dist/**/*",
+    "types/**/*"
+  ],
+  "devDependencies": {
+    "@galacean/engine-design": "workspace:*",
+    "@galacean/engine": "workspace:*"
+  },
+  "peerDependencies": {
+    "@galacean/engine": "workspace:*"
+  }
+}

--- a/packages/physics-havok/src/HavokPhysics.ts
+++ b/packages/physics-havok/src/HavokPhysics.ts
@@ -1,0 +1,143 @@
+import { Quaternion, Vector3 } from "@galacean/engine";
+import {
+  IBoxColliderShape,
+  ICapsuleColliderShape,
+  ICharacterController,
+  ICollider,
+  ICollision,
+  IDynamicCollider,
+  IFixedJoint,
+  IHingeJoint,
+  IPhysics,
+  IPhysicsManager,
+  IPhysicsMaterial,
+  IPhysicsScene,
+  IPlaneColliderShape,
+  ISphereColliderShape,
+  ISpringJoint,
+  IStaticCollider
+} from "@galacean/engine-design";
+
+/**
+ * Placeholder implementation of the {@link IPhysics} interface backed by Havok.
+ *
+ * The actual Havok runtime binding is expected to be provided by host applications.
+ * Until that happens every factory method will throw to highlight the missing integration
+ * rather than failing silently at runtime.
+ */
+export class HavokPhysics implements IPhysics {
+  private readonly _message =
+    "Havok physics runtime has not been integrated yet. Make sure the native bindings are available.";
+
+  /** @inheritdoc */
+  async initialize(): Promise<void> {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  createPhysicsManager(): IPhysicsManager {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  createPhysicsScene(
+    _physicsManager: IPhysicsManager,
+    _onContactEnter?: (collision: ICollision) => void,
+    _onContactExit?: (collision: ICollision) => void,
+    _onContactStay?: (collision: ICollision) => void,
+    _onTriggerEnter?: (obj1: number, obj2: number) => void,
+    _onTriggerExit?: (obj1: number, obj2: number) => void,
+    _onTriggerStay?: (obj1: number, obj2: number) => void
+  ): IPhysicsScene {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  createDynamicCollider(_position: Vector3, _rotation: Quaternion): IDynamicCollider {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  createStaticCollider(_position: Vector3, _rotation: Quaternion): IStaticCollider {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  createCharacterController(): ICharacterController {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  createPhysicsMaterial(
+    _staticFriction: number,
+    _dynamicFriction: number,
+    _bounciness: number,
+    _frictionCombine: number,
+    _bounceCombine: number
+  ): IPhysicsMaterial {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  createBoxColliderShape(
+    _uniqueID: number,
+    _size: Vector3,
+    _material: IPhysicsMaterial
+  ): IBoxColliderShape {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  createSphereColliderShape(
+    _uniqueID: number,
+    _radius: number,
+    _material: IPhysicsMaterial
+  ): ISphereColliderShape {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  createPlaneColliderShape(_uniqueID: number, _material: IPhysicsMaterial): IPlaneColliderShape {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  createCapsuleColliderShape(
+    _uniqueID: number,
+    _radius: number,
+    _height: number,
+    _material: IPhysicsMaterial
+  ): ICapsuleColliderShape {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  createFixedJoint(_collider: ICollider): IFixedJoint {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  createHingeJoint(_collider: ICollider): IHingeJoint {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  createSpringJoint(_collider: ICollider): ISpringJoint {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  getColliderLayerCollision(_layer1: number, _layer2: number): boolean {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  setColliderLayerCollision(_layer1: number, _layer2: number, _isCollide: boolean): void {
+    throw new Error(this._message);
+  }
+
+  /** @inheritdoc */
+  destroy(): void {
+    // Nothing to clean up for the placeholder implementation.
+  }
+}

--- a/packages/physics-havok/src/index.ts
+++ b/packages/physics-havok/src/index.ts
@@ -1,0 +1,6 @@
+export { HavokPhysics } from "./HavokPhysics";
+
+//@ts-ignore
+export const version = `__buildVersion`;
+
+console.log(`Galacean Engine Physics Havok Version: ${version}`);

--- a/packages/physics-havok/tsconfig.json
+++ b/packages/physics-havok/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "module": "esnext",
+        "target": "esnext",
+        "declaration": true,
+        "moduleResolution": "node",
+        "allowSyntheticDefaultImports": true,
+        "experimentalDecorators": true,
+        "declarationDir": "types",
+        "emitDeclarationOnly": true,
+        "noImplicitOverride": true,
+        "sourceMap": true,
+        "incremental": false,
+        "skipLibCheck": true,
+        "stripInternal": true
+    },
+    "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add a new `@galacean/engine-physics-havok` package to house the Havok-backed implementation of the `IPhysics` interface
- provide a placeholder `HavokPhysics` class that surfaces clear errors until the native bindings are wired up
- document installation and usage patterns for the new Havok physics backend package

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7f936ca0c8328b340d7708c3b45e6