### PR TITLE
refactor(loader): lazy prefab resolution + structured ComponentSelector

### DIFF
--- a/packages/loader/src/SceneLoader.ts
+++ b/packages/loader/src/SceneLoader.ts
@@ -11,7 +11,7 @@ import {
   ResourceManager,
   Scene
 } from "@galacean/engine-core";
-import { SpecularMode, type SceneFile } from "./scene-format/types";
+import { SpecularMode, type RefItem, type SceneFile } from "./scene-format/types";
 import { ParserContext, ParserType, SceneParser } from "./resource-deserialize";
 
 /**
@@ -21,7 +21,8 @@ import { ParserContext, ParserType, SceneParser } from "./resource-deserialize";
 export function applySceneData(
   scene: Scene,
   sceneData: SceneFile["scene"],
-  resourceManager: ResourceManager
+  resourceManager: ResourceManager,
+  refs: RefItem[]
 ): Promise<void> {
   const promises: Promise<any>[] = [];
 
@@ -39,21 +40,23 @@ export function applySceneData(
       scene.ambientLight.diffuseSolidColor.set(solidColor[0], solidColor[1], solidColor[2], solidColor[3]);
     }
 
-    if (useCustomAmbient && ambient.customAmbientLight) {
+    if (useCustomAmbient && ambient.customAmbientLight != null) {
+      const ref = refs[ambient.customAmbientLight];
       promises.push(
         resourceManager
           // @ts-ignore
-          .getResourceByRef<any>(ambient.customAmbientLight)
+          .getResourceByRef<any>({ $ref: ref.url, key: ref.key })
           .then((ambientLight) => {
             scene.ambientLight.specularTexture = ambientLight?.specularTexture;
           })
       );
     }
 
-    if (ambient.ambientLight && (!useCustomAmbient || useSH)) {
+    if (ambient.ambientLight != null && (!useCustomAmbient || useSH)) {
+      const ref = refs[ambient.ambientLight];
       promises.push(
         // @ts-ignore
-        resourceManager.getResourceByRef<any>(ambient.ambientLight).then((ambientLight) => {
+        resourceManager.getResourceByRef<any>({ $ref: ref.url, key: ref.key }).then((ambientLight) => {
           if (!useCustomAmbient) {
             scene.ambientLight.specularTexture = ambientLight?.specularTexture;
           }
@@ -77,16 +80,18 @@ export function applySceneData(
       break;
     }
     case BackgroundMode.Sky:
-      if (background.skyMesh && background.skyMaterial) {
+      if (background.skyMesh != null && background.skyMaterial != null) {
+        const meshRef = refs[background.skyMesh];
+        const matRef = refs[background.skyMaterial];
         const skyMeshPromise = resourceManager
           // @ts-ignore
-          .getResourceByRef<Mesh>(background.skyMesh)
+          .getResourceByRef<Mesh>({ $ref: meshRef.url, key: meshRef.key })
           .then((mesh) => {
             scene.background.sky.mesh = mesh;
           });
         const skyMaterialPromise = resourceManager
           // @ts-ignore
-          .getResourceByRef(background.skyMaterial)
+          .getResourceByRef({ $ref: matRef.url, key: matRef.key })
           .then((material) => {
             scene.background.sky.material = material;
           });
@@ -96,10 +101,11 @@ export function applySceneData(
       }
       break;
     case BackgroundMode.Texture:
-      if (background.texture) {
+      if (background.texture != null) {
+        const texRef = refs[background.texture];
         const backgroundPromise = resourceManager
           // @ts-ignore
-          .getResourceByRef<any>(background.texture)
+          .getResourceByRef<any>({ $ref: texRef.url, key: texRef.key })
           .then((texture) => {
             scene.background.texture = texture;
           });
@@ -176,7 +182,7 @@ class SceneLoader extends Loader<Scene> {
           context._setTaskCompleteProgress = setTaskCompleteProgress;
           parser.start();
           return parser.promise.then(() => {
-            return applySceneData(scene, data.scene, resourceManager).then(() => {
+            return applySceneData(scene, data.scene, resourceManager, data.refs).then(() => {
               resolve(scene);
             });
           });

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -31,10 +31,9 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     public readonly data: HierarchyFile,
     public readonly context: V
   ) {
-    const version = (data as Partial<HierarchyFile>).version;
-    if (version !== "2.0") {
+    if (data.version !== "2.0") {
       const resourceType = context.type === ParserType.Scene ? "scene" : "prefab";
-      throw new Error(`Unsupported ${resourceType} format version "${version ?? "missing"}". Expected "2.0".`);
+      throw new Error(`Unsupported ${resourceType} format version "${data.version}". Expected "2.0".`);
     }
 
     this._engine = this.context.engine;
@@ -95,7 +94,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       }
     }
 
-    return Promise.all(promises).then(() => {});
+    return Promise.all(promises) as any;
   }
 
   // ---------------------------------------------------------------------------
@@ -169,7 +168,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       }
     }
 
-    return Promise.all(promises).then(() => {});
+    return Promise.all(promises) as any;
   }
 
   // ---------------------------------------------------------------------------
@@ -247,7 +246,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       }
     }
 
-    return Promise.all(promises).then(() => {});
+    return Promise.all(promises) as any;
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -306,6 +306,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     let entity = root;
     for (let i = 0, n = path.length; i < n; i++) {
       entity = entity.children[path[i]];
+      if (!entity) throw new Error(`Override target entity not found at path [${path}], failed at depth ${i}`);
     }
     return entity;
   }
@@ -317,6 +318,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     entity.getComponents(Loader.getClass(selector.type), buffer);
     const result = buffer[selector.index];
     buffer.length = 0;
+    if (!result) throw new Error(`Override target component not found: ${selector.type}/${selector.index}`);
     return result;
   }
 

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -195,10 +195,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       if (overrides.entityProps) {
         for (let j = 0, m = overrides.entityProps.length; j < m; j++) {
           const override = overrides.entityProps[j] as EntityPropOverride;
-          const target = HierarchyParser._resolveEntity(rootEntity, override.path);
-          if (target) {
-            HierarchyParser._applyEntityProps(target, override);
-          }
+          HierarchyParser._applyEntityProps(HierarchyParser._resolveEntity(rootEntity, override.path), override);
         }
       }
 
@@ -207,10 +204,8 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
         for (let j = 0, m = overrides.componentProps.length; j < m; j++) {
           const override = overrides.componentProps[j] as ComponentOverride;
           const entity = HierarchyParser._resolveEntity(rootEntity, override.path);
-          const target = entity ? HierarchyParser._resolveComponent(entity, override.selector) : null;
-          if (target) {
-            promises.push(this._reflectionParser.parseMutationBlock(target, override));
-          }
+          const target = HierarchyParser._resolveComponent(entity, override.selector);
+          promises.push(this._reflectionParser.parseMutationBlock(target, override));
         }
       }
 
@@ -218,12 +213,9 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       if (overrides.addedComponents) {
         for (let j = 0, m = overrides.addedComponents.length; j < m; j++) {
           const added = overrides.addedComponents[j];
-          const target = HierarchyParser._resolveEntity(rootEntity, added.target);
-          if (target) {
-            const compConfig = added.component;
-            const component = HierarchyParser._addComponentFromConfig(target, compConfig);
-            promises.push(this._reflectionParser.parseMutationBlock(component, compConfig));
-          }
+          const entity = HierarchyParser._resolveEntity(rootEntity, added.target);
+          const component = HierarchyParser._addComponentFromConfig(entity, added.component);
+          promises.push(this._reflectionParser.parseMutationBlock(component, added.component));
         }
       }
 
@@ -231,18 +223,14 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       if (overrides.addedEntities) {
         for (let j = 0, m = overrides.addedEntities.length; j < m; j++) {
           const added = overrides.addedEntities[j];
-          const parent = HierarchyParser._resolveEntity(rootEntity, added.parent);
-          if (parent) {
-            this._createInlineEntity(added.entity, parent, promises);
-          }
+          this._createInlineEntity(added.entity, HierarchyParser._resolveEntity(rootEntity, added.parent), promises);
         }
       }
 
       // removedEntities — destroy entities from prefab tree
       if (overrides.removedEntities) {
         for (let j = 0, m = overrides.removedEntities.length; j < m; j++) {
-          const target = HierarchyParser._resolveEntity(rootEntity, overrides.removedEntities[j]);
-          if (target) target.destroy();
+          HierarchyParser._resolveEntity(rootEntity, overrides.removedEntities[j]).destroy();
         }
       }
 
@@ -251,11 +239,9 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
         for (let j = 0, m = overrides.removedComponents.length; j < m; j++) {
           const override = overrides.removedComponents[j];
           const entity = HierarchyParser._resolveEntity(rootEntity, override.path);
-          if (!entity) continue;
           const selectors = override.selectors;
           for (let k = 0, p = selectors.length; k < p; k++) {
-            const target = HierarchyParser._resolveComponent(entity, selectors[k]);
-            if (target) target.destroy();
+            HierarchyParser._resolveComponent(entity, selectors[k]).destroy();
           }
         }
       }
@@ -317,24 +303,20 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   // ---------------------------------------------------------------------------
 
   /** Resolve an entity inside a prefab instance by walking the child-index path from root */
-  private static _resolveEntity(root: Entity, path: number[]): Entity | null {
+  private static _resolveEntity(root: Entity, path: number[]): Entity {
     let entity = root;
     for (let i = 0, n = path.length; i < n; i++) {
-      const idx = path[i];
-      if (idx >= entity.children.length) return null;
-      entity = entity.children[idx];
+      entity = entity.children[path[i]];
     }
     return entity;
   }
 
   /** Resolve a component on an entity by type name + per-type index */
-  private static _resolveComponent(entity: Entity, selector: ComponentSelector): Component | null {
-    const Class = Loader.getClass(selector.type);
-    if (!Class) return null;
+  private static _resolveComponent(entity: Entity, selector: ComponentSelector): Component {
     const buffer = HierarchyParser._componentBuffer;
     buffer.length = 0;
-    entity.getComponents(Class, buffer);
-    const result = buffer[selector.index] ?? null;
+    entity.getComponents(Loader.getClass(selector.type), buffer);
+    const result = buffer[selector.index];
     buffer.length = 0;
     return result;
   }

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -19,16 +19,6 @@ import { ReflectionParser } from "./ReflectionParser";
 /** @Internal */
 export abstract class HierarchyParser<T extends Scene | PrefabResource, V extends ParserContext> {
   private static _componentBuffer: Component[] = [];
-  private static readonly _prefabInstanceInvalidKeys = [
-    "name",
-    "isActive",
-    "layer",
-    "position",
-    "rotation",
-    "scale",
-    "children",
-    "components"
-  ];
 
   readonly promise: Promise<T>;
 
@@ -364,14 +354,10 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
   private static _assertPrefabInstanceEntityShape(entityConfig: PrefabInstanceEntitySchema): void {
     const shape = entityConfig as unknown as Record<string, unknown>;
-    const keys = HierarchyParser._prefabInstanceInvalidKeys;
-    let invalidKeys: string[] | null = null;
-    for (let i = 0, n = keys.length; i < n; i++) {
-      if (shape[keys[i]] != null) {
-        (invalidKeys ??= []).push(keys[i]);
-      }
-    }
-    if (invalidKeys) {
+    const invalidKeys = ["name", "isActive", "layer", "position", "rotation", "scale", "children", "components"].filter(
+      (key) => shape[key] != null
+    );
+    if (invalidKeys.length > 0) {
       throw new Error(
         `Prefab instance entity cannot declare ${invalidKeys.join(
           ", "

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -82,7 +82,6 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       const entityConfig = entities[i];
 
       if (HierarchyParser._isPrefabInstanceEntity(entityConfig)) {
-        HierarchyParser._assertPrefabInstanceEntityShape(entityConfig);
         promises.push(
           this._loadPrefabInstance(entityConfig, engine).then((entity) => {
             entityMap.set(i, entity);
@@ -350,20 +349,6 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
   private static _isPrefabInstanceEntity(entityConfig: EntitySchema): entityConfig is PrefabInstanceEntitySchema {
     return "instance" in entityConfig;
-  }
-
-  private static _assertPrefabInstanceEntityShape(entityConfig: PrefabInstanceEntitySchema): void {
-    const shape = entityConfig as unknown as Record<string, unknown>;
-    const invalidKeys = ["name", "isActive", "layer", "position", "rotation", "scale", "children", "components"].filter(
-      (key) => shape[key] != null
-    );
-    if (invalidKeys.length > 0) {
-      throw new Error(
-        `Prefab instance entity cannot declare ${invalidKeys.join(
-          ", "
-        )} directly. Move root overrides to instance.overrides.entityProps with path: [].`
-      );
-    }
   }
 
   /** Apply entity-level props (name, isActive, layer, transform) to an entity. */

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -3,6 +3,7 @@ import { GLTFResource } from "../../../gltf";
 import { PrefabResource } from "../../../prefab/PrefabResource";
 import {
   type ComponentSchema,
+  type ComponentSelector,
   type ComponentOverride,
   type EntityPropOverride,
   type EntityOverrideProps,
@@ -12,7 +13,7 @@ import {
   type NormalEntitySchema,
   type PrefabInstanceEntitySchema
 } from "../../../scene-format/types";
-import { ParserContext, ParserType, type PrefabInstanceContext } from "./ParserContext";
+import { ParserContext, ParserType } from "./ParserContext";
 import { ReflectionParser } from "./ReflectionParser";
 
 /** @Internal */
@@ -23,8 +24,6 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   protected _reject: (reason: any) => void;
   protected _engine: Engine;
   protected _reflectionParser: ReflectionParser;
-
-  private _prefabContextMap = new WeakMap<Entity, PrefabInstanceContext>();
 
   constructor(
     public readonly data: HierarchyFile,
@@ -206,16 +205,13 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       if (!instance.overrides) continue;
 
       const rootEntity = entityMap.get(i);
-      const ctx = this._prefabContextMap.get(rootEntity);
-      if (!ctx) continue;
-
       const overrides = instance.overrides;
 
       // entityProps — entity-level property overrides
       if (overrides.entityProps) {
         for (let j = 0, m = overrides.entityProps.length; j < m; j++) {
           const override = overrides.entityProps[j] as EntityPropOverride;
-          const target = ctx.entityMap.get(override.path.join("/"));
+          const target = HierarchyParser._resolveEntity(rootEntity, override.path);
           if (target) {
             HierarchyParser._applyEntityProps(target, override);
           }
@@ -227,14 +223,14 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
         const seenTargets = new Set<string>();
         for (let j = 0, m = overrides.componentProps.length; j < m; j++) {
           const override = overrides.componentProps[j] as ComponentOverride;
-          const path = override.path.join("/");
-          const componentKey = path ? `${path}:${override.selector}` : `:${override.selector}`;
-          if (seenTargets.has(componentKey)) {
-            return Promise.reject(new Error(`Duplicate component override for "${componentKey}"`));
+          const dedupKey = `${override.path.join("/")}:${override.selector.type}/${override.selector.index}`;
+          if (seenTargets.has(dedupKey)) {
+            return Promise.reject(new Error(`Duplicate component override for "${dedupKey}"`));
           }
-          seenTargets.add(componentKey);
+          seenTargets.add(dedupKey);
 
-          const target = ctx.components.get(componentKey);
+          const entity = HierarchyParser._resolveEntity(rootEntity, override.path);
+          const target = entity ? HierarchyParser._resolveComponent(entity, override.selector) : null;
           if (target) {
             promises.push(this._reflectionParser.parseMutationBlock(target, override));
           }
@@ -245,8 +241,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       if (overrides.addedComponents) {
         for (let j = 0, m = overrides.addedComponents.length; j < m; j++) {
           const added = overrides.addedComponents[j];
-          const path = added.target.join("/");
-          const target = ctx.entityMap.get(path);
+          const target = HierarchyParser._resolveEntity(rootEntity, added.target);
           if (target) {
             const compConfig = added.component;
             const component = HierarchyParser._addComponentFromConfig(target, compConfig);
@@ -259,8 +254,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       if (overrides.addedEntities) {
         for (let j = 0, m = overrides.addedEntities.length; j < m; j++) {
           const added = overrides.addedEntities[j];
-          const path = added.parent.join("/");
-          const parent = ctx.entityMap.get(path);
+          const parent = HierarchyParser._resolveEntity(rootEntity, added.parent);
           if (parent) {
             this._createInlineEntity(added.entity, parent, promises);
           }
@@ -270,8 +264,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       // removedEntities — destroy entities from prefab tree
       if (overrides.removedEntities) {
         for (let j = 0, m = overrides.removedEntities.length; j < m; j++) {
-          const path = overrides.removedEntities[j].join("/");
-          const target = ctx.entityMap.get(path);
+          const target = HierarchyParser._resolveEntity(rootEntity, overrides.removedEntities[j]);
           if (target) target.destroy();
         }
       }
@@ -280,11 +273,11 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       if (overrides.removedComponents) {
         for (let j = 0, m = overrides.removedComponents.length; j < m; j++) {
           const override = overrides.removedComponents[j];
-          const path = override.path.join("/");
+          const entity = HierarchyParser._resolveEntity(rootEntity, override.path);
+          if (!entity) continue;
           const selectors = override.selectors;
-          for (let k = 0, n = selectors.length; k < n; k++) {
-            const componentKey = path ? `${path}:${selectors[k]}` : `:${selectors[k]}`;
-            const target = ctx.components.get(componentKey);
+          for (let k = 0, p = selectors.length; k < p; k++) {
+            const target = HierarchyParser._resolveComponent(entity, selectors[k]);
             if (target) target.destroy();
           }
         }
@@ -312,41 +305,9 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
               : prefabResource.instantiateSceneRoot();
 
           this._onEntityCreated(entity);
-          const instanceContext = HierarchyParser._buildInstanceContext(entity);
-          this._prefabContextMap.set(entity, instanceContext);
-
           return entity;
         })
     );
-  }
-
-  private static _buildInstanceContext(entity: Entity): PrefabInstanceContext {
-    const ctx: PrefabInstanceContext = {
-      entityMap: new Map(),
-      components: new Map()
-    };
-    HierarchyParser._walkPrefabTree(entity, ctx, "");
-    return ctx;
-  }
-
-  private static _walkPrefabTree(entity: Entity, ctx: PrefabInstanceContext, path: string): void {
-    ctx.entityMap.set(path, entity);
-    const componentIndexMap: Record<string, number> = {};
-
-    // Must iterate _components directly to preserve insertion order — the per-type index
-    // (e.g. "MeshRenderer/0") used by prefab override selectors depends on this ordering.
-    // @ts-ignore
-    entity._components.forEach((component: Component) => {
-      // @ts-ignore
-      const name = Loader.getClassName(component.constructor);
-      if (!(name in componentIndexMap)) componentIndexMap[name] = 0;
-      ctx.components.set(`${path}:${name}/${componentIndexMap[name]++}`, component);
-    });
-
-    for (let i = 0, n = entity.children.length; i < n; i++) {
-      const childPath = path ? `${path}/${i}` : `${i}`;
-      HierarchyParser._walkPrefabTree(entity.children[i], ctx, childPath);
-    }
   }
 
   // ---------------------------------------------------------------------------
@@ -377,6 +338,24 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   // ---------------------------------------------------------------------------
   // Utilities
   // ---------------------------------------------------------------------------
+
+  /** Resolve an entity inside a prefab instance by walking the child-index path from root */
+  private static _resolveEntity(root: Entity, path: number[]): Entity | null {
+    let entity = root;
+    for (let i = 0, n = path.length; i < n; i++) {
+      const idx = path[i];
+      if (idx >= entity.children.length) return null;
+      entity = entity.children[idx];
+    }
+    return entity;
+  }
+
+  /** Resolve a component on an entity by type name + per-type index */
+  private static _resolveComponent(entity: Entity, selector: ComponentSelector): Component | null {
+    const Class = Loader.getClass(selector.type);
+    if (!Class) return null;
+    return entity.getComponents(Class, [])[selector.index] ?? null;
+  }
 
   /** Resolve component class from config and add to entity. Throws if class is not registered. */
   private static _addComponentFromConfig(entity: Entity, config: ComponentSchema): Component {

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -313,9 +313,11 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
   /** Resolve a component on an entity by type name + per-type index */
   private static _resolveComponent(entity: Entity, selector: ComponentSelector): Component {
+    const type = Loader.getClass(selector.type);
+    if (!type) throw new Error(`Override target component type "${selector.type}" is not registered`);
     const buffer = HierarchyParser._componentBuffer;
     buffer.length = 0;
-    entity.getComponents(Loader.getClass(selector.type), buffer);
+    entity.getComponents(type, buffer);
     const result = buffer[selector.index];
     buffer.length = 0;
     if (!result) throw new Error(`Override target component not found: ${selector.type}/${selector.index}`);

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -306,7 +306,8 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     let entity = root;
     for (let i = 0, n = path.length; i < n; i++) {
       entity = entity.children[path[i]];
-      if (!entity) throw new Error(`Override target entity not found at path [${path}], failed at depth ${i}`);
+      if (!entity)
+        throw new Error(`HierarchyParser: override target entity not found at path [${path}], failed at depth ${i}`);
     }
     return entity;
   }
@@ -314,13 +315,14 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   /** Resolve a component on an entity by type name + per-type index */
   private static _resolveComponent(entity: Entity, selector: ComponentSelector): Component {
     const type = Loader.getClass(selector.type);
-    if (!type) throw new Error(`Override target component type "${selector.type}" is not registered`);
+    if (!type) throw new Error(`HierarchyParser: override target component type "${selector.type}" is not registered`);
     const buffer = HierarchyParser._componentBuffer;
     buffer.length = 0;
     entity.getComponents(type, buffer);
     const result = buffer[selector.index];
     buffer.length = 0;
-    if (!result) throw new Error(`Override target component not found: ${selector.type}/${selector.index}`);
+    if (!result)
+      throw new Error(`HierarchyParser: override target component not found: ${selector.type}/${selector.index}`);
     return result;
   }
 

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -11,7 +11,8 @@ import {
   type HierarchyFile,
   type InlineEntitySchema,
   type NormalEntitySchema,
-  type PrefabInstanceEntitySchema
+  type PrefabInstanceEntitySchema,
+  type RefItem
 } from "../../../scene-format/types";
 import { ParserContext, ParserType } from "./ParserContext";
 import { ReflectionParser } from "./ReflectionParser";
@@ -41,7 +42,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       this._reject = reject;
       this._resolve = resolve;
     });
-    this._reflectionParser = new ReflectionParser(context);
+    this._reflectionParser = new ReflectionParser(context, data.refs);
   }
 
   public start() {
@@ -145,7 +146,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
       for (let j = 0, m = componentIndices.length; j < m; j++) {
         const config = allComponents[componentIndices[j]];
-        const component = HierarchyParser._addComponentFromConfig(entity, config);
+        const component = HierarchyParser._addComponentFromConfig(entity, config, this.data.refs);
         componentPairs.push({ component, config });
       }
     }
@@ -213,7 +214,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
         for (let j = 0, m = overrides.addedComponents.length; j < m; j++) {
           const added = overrides.addedComponents[j];
           const entity = HierarchyParser._resolveEntity(rootEntity, added.target);
-          const component = HierarchyParser._addComponentFromConfig(entity, added.component);
+          const component = HierarchyParser._addComponentFromConfig(entity, added.component, this.data.refs);
           promises.push(this._reflectionParser.parseMutationBlock(component, added.component));
         }
       }
@@ -255,11 +256,12 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
   private _loadPrefabInstance(entityConfig: PrefabInstanceEntitySchema, engine: Engine): Promise<Entity> {
     const instance = entityConfig.instance;
+    const refItem = this.data.refs[instance.asset];
 
     return (
       engine.resourceManager
         // @ts-ignore
-        .getResourceByRef<Entity>(instance.asset)
+        .getResourceByRef<Entity>({ $ref: refItem.url, key: refItem.key })
         .then((prefabResource: PrefabResource | GLTFResource) => {
           const entity =
             prefabResource instanceof PrefabResource
@@ -285,7 +287,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     if (config.components) {
       for (let i = 0, n = config.components.length; i < n; i++) {
         const compConfig = config.components[i];
-        const component = HierarchyParser._addComponentFromConfig(entity, compConfig);
+        const component = HierarchyParser._addComponentFromConfig(entity, compConfig, this.data.refs);
         promises.push(this._reflectionParser.parseMutationBlock(component, compConfig));
       }
     }
@@ -327,8 +329,8 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   }
 
   /** Resolve component class from config and add to entity. Throws if class is not registered. */
-  private static _addComponentFromConfig(entity: Entity, config: ComponentSchema): Component {
-    const key = config.script ? config.script.$ref : config.type;
+  private static _addComponentFromConfig(entity: Entity, config: ComponentSchema, refs: RefItem[]): Component {
+    const key = config.script ? refs[config.script.$ref].url : config.type;
     const Class = Loader.getClass(key);
     if (!Class) throw new Error(`Loader.getClass: class "${key}" is not registered`);
     return entity.addComponent(Class);

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -47,8 +47,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     this._parseEntities()
       .then(() => this._organizeEntities())
       .then(() => this._parseComponents())
-      .then(() => this._parseComponentsProps())
-      .then(() => this._parseComponentsCalls())
+      .then(() => this._parseComponentsPropsAndCalls())
       .then(() => this._parsePrefabOverrides())
       .then(() => this._clearAndResolve())
       .then(this._resolve)
@@ -153,10 +152,10 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   }
 
   // ---------------------------------------------------------------------------
-  // Stage 4: Apply props to components
+  // Stage 4: Apply props and execute calls on components
   // ---------------------------------------------------------------------------
 
-  private _parseComponentsProps(): Promise<void> {
+  private _parseComponentsPropsAndCalls(): Promise<void> {
     const { componentPairs } = this.context;
     const reflectionParser = this._reflectionParser;
     const promises: Promise<any>[] = [];
@@ -164,22 +163,6 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     for (let i = 0, n = componentPairs.length; i < n; i++) {
       const { component, config } = componentPairs[i];
       promises.push(reflectionParser.parseProps(component, config.props));
-    }
-
-    return Promise.all(promises).then(() => {});
-  }
-
-  // ---------------------------------------------------------------------------
-  // Stage 4.5: Execute component calls after props
-  // ---------------------------------------------------------------------------
-
-  private _parseComponentsCalls(): Promise<void> {
-    const { componentPairs } = this.context;
-    const reflectionParser = this._reflectionParser;
-    const promises: Promise<any>[] = [];
-
-    for (let i = 0, n = componentPairs.length; i < n; i++) {
-      const { component, config } = componentPairs[i];
       if (config.calls) {
         promises.push(reflectionParser.parseCalls(component, config.calls));
       }
@@ -220,15 +203,8 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
       // componentProps — component-level property overrides
       if (overrides.componentProps) {
-        const seenTargets = new Set<string>();
         for (let j = 0, m = overrides.componentProps.length; j < m; j++) {
           const override = overrides.componentProps[j] as ComponentOverride;
-          const dedupKey = `${override.path.join("/")}:${override.selector.type}/${override.selector.index}`;
-          if (seenTargets.has(dedupKey)) {
-            return Promise.reject(new Error(`Duplicate component override for "${dedupKey}"`));
-          }
-          seenTargets.add(dedupKey);
-
           const entity = HierarchyParser._resolveEntity(rootEntity, override.path);
           const target = entity ? HierarchyParser._resolveComponent(entity, override.selector) : null;
           if (target) {
@@ -350,11 +326,18 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     return entity;
   }
 
+  private static _componentBuffer: Component[] = [];
+
   /** Resolve a component on an entity by type name + per-type index */
   private static _resolveComponent(entity: Entity, selector: ComponentSelector): Component | null {
     const Class = Loader.getClass(selector.type);
     if (!Class) return null;
-    return entity.getComponents(Class, [])[selector.index] ?? null;
+    const buffer = HierarchyParser._componentBuffer;
+    buffer.length = 0;
+    entity.getComponents(Class, buffer);
+    const result = buffer[selector.index] ?? null;
+    buffer.length = 0;
+    return result;
   }
 
   /** Resolve component class from config and add to entity. Throws if class is not registered. */
@@ -369,12 +352,27 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     return "instance" in entityConfig;
   }
 
+  private static readonly _prefabInstanceInvalidKeys = [
+    "name",
+    "isActive",
+    "layer",
+    "position",
+    "rotation",
+    "scale",
+    "children",
+    "components"
+  ];
+
   private static _assertPrefabInstanceEntityShape(entityConfig: PrefabInstanceEntitySchema): void {
     const shape = entityConfig as unknown as Record<string, unknown>;
-    const invalidKeys = ["name", "isActive", "layer", "position", "rotation", "scale", "children", "components"].filter(
-      (key) => shape[key] != null
-    );
-    if (invalidKeys.length > 0) {
+    const keys = HierarchyParser._prefabInstanceInvalidKeys;
+    let invalidKeys: string[] | null = null;
+    for (let i = 0, n = keys.length; i < n; i++) {
+      if (shape[keys[i]] != null) {
+        (invalidKeys ??= []).push(keys[i]);
+      }
+    }
+    if (invalidKeys) {
       throw new Error(
         `Prefab instance entity cannot declare ${invalidKeys.join(
           ", "

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -18,6 +18,18 @@ import { ReflectionParser } from "./ReflectionParser";
 
 /** @Internal */
 export abstract class HierarchyParser<T extends Scene | PrefabResource, V extends ParserContext> {
+  private static _componentBuffer: Component[] = [];
+  private static readonly _prefabInstanceInvalidKeys = [
+    "name",
+    "isActive",
+    "layer",
+    "position",
+    "rotation",
+    "scale",
+    "children",
+    "components"
+  ];
+
   readonly promise: Promise<T>;
 
   protected _resolve: (item: T) => void;
@@ -326,8 +338,6 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     return entity;
   }
 
-  private static _componentBuffer: Component[] = [];
-
   /** Resolve a component on an entity by type name + per-type index */
   private static _resolveComponent(entity: Entity, selector: ComponentSelector): Component | null {
     const Class = Loader.getClass(selector.type);
@@ -351,17 +361,6 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   private static _isPrefabInstanceEntity(entityConfig: EntitySchema): entityConfig is PrefabInstanceEntitySchema {
     return "instance" in entityConfig;
   }
-
-  private static readonly _prefabInstanceInvalidKeys = [
-    "name",
-    "isActive",
-    "layer",
-    "position",
-    "rotation",
-    "scale",
-    "children",
-    "components"
-  ];
 
   private static _assertPrefabInstanceEntityShape(entityConfig: PrefabInstanceEntitySchema): void {
     const shape = entityConfig as unknown as Record<string, unknown>;

--- a/packages/loader/src/resource-deserialize/resources/parser/ParserContext.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ParserContext.ts
@@ -6,14 +6,6 @@ export enum ParserType {
   Scene
 }
 
-/** Prefab instance context for override resolution. */
-export interface PrefabInstanceContext {
-  /** Path string → Entity (e.g., "" → root, "0" → first child, "0/1" → ...) */
-  entityMap: Map<string, Entity>;
-  /** Component key → Component (e.g., "0:MeshRenderer/0") */
-  components: Map<string, Component>;
-}
-
 /**
  * @internal
  */

--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -1,8 +1,10 @@
-import { Loader } from "@galacean/engine-core";
+import { Component, Loader } from "@galacean/engine-core";
 import type { CallSpec, MutationBlock } from "../../../scene-format/types";
 import { ParserContext, ParserType } from "./ParserContext";
 
 export class ReflectionParser {
+  private static _componentBuffer: Component[] = [];
+
   constructor(private readonly _context: ParserContext) {}
 
   /**
@@ -165,8 +167,6 @@ export class ReflectionParser {
     });
     return Promise.all(promises).then(() => signal);
   }
-
-  private static _componentBuffer: any[] = [];
 
   private _resolveComponent(comp: { entity: number; type: string; index: number }): any {
     const entity = this._context.entityMap.get(comp.entity);

--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -129,7 +129,7 @@ export class ReflectionParser {
         obj.$signal as Array<{
           target: { $component: { entity: number; type: string; index: number } };
           methodName: string;
-          arguments?: unknown[];
+          args?: unknown[];
         }>
       );
     }
@@ -151,7 +151,7 @@ export class ReflectionParser {
     listeners: Array<{
       target: { $component: { entity: number; type: string; index: number } };
       methodName: string;
-      arguments?: unknown[];
+      args?: unknown[];
     }>
   ): Promise<any> {
     if (!signal || typeof signal.on !== "function") {
@@ -161,7 +161,7 @@ export class ReflectionParser {
       const targetComponent = this._resolveComponent(listener.target.$component);
       if (!targetComponent) return Promise.resolve();
 
-      return Promise.all((listener.arguments ?? []).map((a) => this._resolveValue(a))).then((resolvedArgs) => {
+      return Promise.all((listener.args ?? []).map((a) => this._resolveValue(a))).then((resolvedArgs) => {
         signal.on(targetComponent, listener.methodName, ...resolvedArgs);
       });
     });

--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -1,5 +1,5 @@
 import { Component, Loader } from "@galacean/engine-core";
-import type { CallSpec, MutationBlock } from "../../../scene-format/types";
+import type { CallSpec, ComponentRef, MutationBlock, SignalListener } from "../../../scene-format/types";
 import { ParserContext, ParserType } from "./ParserContext";
 
 export class ReflectionParser {
@@ -119,19 +119,12 @@ export class ReflectionParser {
 
     // $component — component reference: { entity, type, index }
     if ("$component" in obj) {
-      return Promise.resolve(this._resolveComponent(obj.$component as { entity: number; type: string; index: number }));
+      return Promise.resolve(this._resolveComponent(obj.$component as ComponentRef));
     }
 
     // $signal — signal binding: register listeners on the existing Signal instance
     if ("$signal" in obj) {
-      return this._resolveSignal(
-        originValue,
-        obj.$signal as Array<{
-          target: { $component: { entity: number; type: string; index: number } };
-          methodName: string;
-          args?: unknown[];
-        }>
-      );
+      return this._resolveSignal(originValue, obj.$signal as SignalListener[]);
     }
 
     // Plain object — recurse each value, modifying originValue in place or building a new object
@@ -146,14 +139,7 @@ export class ReflectionParser {
     return Promise.all(promises).then(() => target);
   }
 
-  private _resolveSignal(
-    signal: any,
-    listeners: Array<{
-      target: { $component: { entity: number; type: string; index: number } };
-      methodName: string;
-      args?: unknown[];
-    }>
-  ): Promise<any> {
+  private _resolveSignal(signal: any, listeners: SignalListener[]): Promise<any> {
     if (!signal || typeof signal.on !== "function") {
       return Promise.reject(new Error("$signal requires a pre-initialized Signal instance on the target property"));
     }
@@ -168,7 +154,7 @@ export class ReflectionParser {
     return Promise.all(promises).then(() => signal);
   }
 
-  private _resolveComponent(comp: { entity: number; type: string; index: number }): Component | null {
+  private _resolveComponent(comp: ComponentRef): Component | null {
     const entity = this._context.entityMap.get(comp.entity);
     if (!entity) return null;
     const type = Loader.getClass(comp.type);

--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -166,11 +166,18 @@ export class ReflectionParser {
     return Promise.all(promises).then(() => signal);
   }
 
+  private static _componentBuffer: any[] = [];
+
   private _resolveComponent(comp: { entity: number; type: string; index: number }): any {
     const entity = this._context.entityMap.get(comp.entity);
     if (!entity) return null;
     const type = Loader.getClass(comp.type);
     if (!type) return null;
-    return entity.getComponents(type, [])[comp.index] ?? null;
+    const buffer = ReflectionParser._componentBuffer;
+    buffer.length = 0;
+    entity.getComponents(type, buffer);
+    const result = buffer[comp.index] ?? null;
+    buffer.length = 0;
+    return result;
   }
 }

--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -1,11 +1,14 @@
 import { Component, Loader } from "@galacean/engine-core";
-import type { CallSpec, ComponentRef, MutationBlock, SignalListener } from "../../../scene-format/types";
+import type { CallSpec, ComponentRef, MutationBlock, RefItem, SignalListener } from "../../../scene-format/types";
 import { ParserContext, ParserType } from "./ParserContext";
 
 export class ReflectionParser {
   private static _componentBuffer: Component[] = [];
 
-  constructor(private readonly _context: ParserContext) {}
+  constructor(
+    private readonly _context: ParserContext,
+    private readonly _refs: RefItem[]
+  ) {}
 
   /**
    * Apply v2 props to a component/object instance.
@@ -84,12 +87,12 @@ export class ReflectionParser {
 
     const obj = value as Record<string, unknown>;
 
-    // $ref — asset reference
+    // $ref — asset reference (index into refs array)
     if ("$ref" in obj) {
       const { _context: context } = this;
-      const ref = obj as { $ref: string; key?: string };
+      const refItem = this._refs[obj.$ref as number];
       // @ts-ignore
-      return context.resourceManager.getResourceByRef(ref).then((resource) => {
+      return context.resourceManager.getResourceByRef({ $ref: refItem.url, key: refItem.key }).then((resource) => {
         if (resource && context.type === ParserType.Prefab) {
           // @ts-ignore
           context.resource._addDependenceAsset(resource);

--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -168,7 +168,7 @@ export class ReflectionParser {
     return Promise.all(promises).then(() => signal);
   }
 
-  private _resolveComponent(comp: { entity: number; type: string; index: number }): any {
+  private _resolveComponent(comp: { entity: number; type: string; index: number }): Component | null {
     const entity = this._context.entityMap.get(comp.entity);
     if (!entity) return null;
     const type = Loader.getClass(comp.type);

--- a/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
@@ -1,14 +1,5 @@
-import { BackgroundMode, DiffuseMode, Scene } from "@galacean/engine-core";
-import {
-  type CallSpec,
-  type MutationBlock,
-  SpecularMode,
-  type ComponentSchema,
-  type EntitySchema,
-  type InlineEntitySchema,
-  type SceneFile,
-  type HierarchyFile
-} from "../../../scene-format/types";
+import { Scene } from "@galacean/engine-core";
+import { type SceneFile } from "../../../scene-format/types";
 import { HierarchyParser } from "../parser/HierarchyParser";
 import { ParserContext } from "../parser/ParserContext";
 
@@ -28,42 +19,11 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext> {
   _collectDependentAssets(data: SceneFile): void {
     const context = this.context;
     const resourceManager = context.resourceManager;
-    this._parseDependentAssets(data);
-    const scene = data.scene;
-    const ambient = scene.ambient;
-    if (ambient) {
-      const useCustomAmbient = ambient.specularMode === SpecularMode.Custom;
-      const useSH = ambient.diffuseMode === DiffuseMode.SphericalHarmonics;
-      const { customAmbientLight, ambientLight } = ambient;
-      if (useCustomAmbient && customAmbientLight) {
-        context._addDependentAsset(
-          customAmbientLight.$ref,
-          // @ts-ignore
-          resourceManager.getResourceByRef(customAmbientLight)
-        );
-      }
-      if (ambientLight && (!useCustomAmbient || useSH)) {
-        // @ts-ignore
-        context._addDependentAsset(ambientLight.$ref, resourceManager.getResourceByRef(ambientLight));
-      }
-    }
-
-    const background = scene.background;
-    const backgroundMode = background.mode;
-    if (backgroundMode === BackgroundMode.Texture) {
-      const texture = background.texture;
-      if (texture) {
-        // @ts-ignore
-        context._addDependentAsset(texture.$ref, resourceManager.getResourceByRef(texture));
-      }
-    } else if (backgroundMode === BackgroundMode.Sky) {
-      const { skyMesh, skyMaterial } = background;
-      if (skyMesh && skyMaterial) {
-        // @ts-ignore
-        context._addDependentAsset(skyMesh.$ref, resourceManager.getResourceByRef(skyMesh));
-        // @ts-ignore
-        context._addDependentAsset(skyMaterial.$ref, resourceManager.getResourceByRef(skyMaterial));
-      }
+    const refs = data.refs;
+    for (let i = 0, n = refs.length; i < n; i++) {
+      const ref = refs[i];
+      // @ts-ignore
+      context._addDependentAsset(ref.url, resourceManager.getResourceByRef({ $ref: ref.url, key: ref.key }));
     }
   }
 
@@ -78,122 +38,5 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext> {
   protected override _clearAndResolve() {
     this.context.clear();
     return this.scene;
-  }
-
-  private _parseDependentAssets(file: HierarchyFile): void {
-    const entities = file.entities;
-    const components = file.components;
-    const context = this.context;
-
-    for (let i = 0, n = entities.length; i < n; i++) {
-      const entity = entities[i];
-      if (this._isPrefabInstanceEntity(entity)) {
-        const asset = entity.instance.asset;
-        // @ts-ignore
-        context._addDependentAsset(asset.$ref, context.resourceManager.getResourceByRef(asset));
-
-        // Scan overrides for additional asset refs
-        const overrides = entity.instance.overrides;
-        if (overrides) {
-          if (overrides.componentProps) {
-            for (let j = 0, m = overrides.componentProps.length; j < m; j++) {
-              this._searchMutationBlock(overrides.componentProps[j]);
-            }
-          }
-          if (overrides.addedComponents) {
-            for (let j = 0, m = overrides.addedComponents.length; j < m; j++) {
-              const comp = overrides.addedComponents[j].component;
-              this._searchComponentDependentAssets(comp);
-            }
-          }
-          if (overrides.addedEntities) {
-            for (let j = 0, m = overrides.addedEntities.length; j < m; j++) {
-              this._searchInlineEntityDependentAssets(overrides.addedEntities[j].entity);
-            }
-          }
-        }
-      } else {
-        const componentIndices = entity.components;
-        if (!componentIndices) continue;
-        for (let j = 0, m = componentIndices.length; j < m; j++) {
-          this._searchComponentDependentAssets(components[componentIndices[j]]);
-        }
-      }
-    }
-  }
-
-  private _isPrefabInstanceEntity(entity: EntitySchema): entity is Extract<EntitySchema, { instance: unknown }> {
-    return !!entity.instance;
-  }
-
-  private _searchComponentDependentAssets(comp: ComponentSchema): void {
-    const context = this.context;
-    if (comp.script) {
-      context._addDependentAsset(
-        comp.script.$ref,
-        // @ts-ignore
-        context.resourceManager.getResourceByRef(comp.script)
-      );
-    }
-    if (comp.props) {
-      this._searchDependentAssets(comp.props);
-    }
-    if (comp.calls) {
-      this._searchCalls(comp.calls);
-    }
-  }
-
-  private _searchInlineEntityDependentAssets(entity: InlineEntitySchema): void {
-    if (entity.components) {
-      for (let i = 0, n = entity.components.length; i < n; i++) {
-        this._searchComponentDependentAssets(entity.components[i]);
-      }
-    }
-    if (entity.children) {
-      for (let i = 0, n = entity.children.length; i < n; i++) {
-        this._searchInlineEntityDependentAssets(entity.children[i]);
-      }
-    }
-  }
-
-  private _searchDependentAssets(value: any): void {
-    if (Array.isArray(value)) {
-      for (let i = 0, n = value.length; i < n; i++) {
-        this._searchDependentAssets(value[i]);
-      }
-    } else if (value != null && typeof value === "object") {
-      if ("$ref" in value) {
-        const context = this.context;
-        // @ts-ignore
-        context._addDependentAsset(value.$ref, context.resourceManager.getResourceByRef(value));
-      } else {
-        for (const key in value) {
-          this._searchDependentAssets(value[key]);
-        }
-      }
-    }
-  }
-
-  private _searchMutationBlock(block?: MutationBlock): void {
-    if (!block) return;
-    if (block.props) {
-      this._searchDependentAssets(block.props);
-    }
-    if (block.calls) {
-      this._searchCalls(block.calls);
-    }
-  }
-
-  private _searchCalls(calls?: CallSpec[]): void {
-    if (!calls) return;
-    for (let i = 0, n = calls.length; i < n; i++) {
-      const call = calls[i];
-      if (call.args) {
-        this._searchDependentAssets(call.args);
-      }
-      if (call.result) {
-        this._searchMutationBlock(call.result);
-      }
-    }
   }
 }

--- a/packages/loader/src/scene-format/types.ts
+++ b/packages/loader/src/scene-format/types.ts
@@ -71,6 +71,18 @@ export interface ComponentSelector {
   index: number;
 }
 
+export interface ComponentRef {
+  entity: number;
+  type: string;
+  index: number;
+}
+
+export interface SignalListener {
+  target: { $component: ComponentRef };
+  methodName: string;
+  args?: unknown[];
+}
+
 export interface ComponentOverride extends MutationBlock {
   path: number[];
   selector: ComponentSelector;

--- a/packages/loader/src/scene-format/types.ts
+++ b/packages/loader/src/scene-format/types.ts
@@ -15,9 +15,13 @@ import {
 export type Vec3Tuple = [number, number, number];
 export type Vec4Tuple = [number, number, number, number];
 
-export interface AssetRef {
-  $ref: string;
+export interface RefItem {
+  url: string;
   key?: string;
+}
+
+export interface AssetRef {
+  $ref: number;
 }
 
 export interface CallSpec {
@@ -103,7 +107,7 @@ export interface InstanceOverrides {
 }
 
 export interface InstanceSchema {
-  asset: AssetRef;
+  asset: number;
   overrides?: InstanceOverrides;
 }
 
@@ -127,6 +131,7 @@ export enum SpecularMode {
 /** Common base for v2 scene and prefab files. */
 export interface HierarchyFile {
   version: "2.0";
+  refs: RefItem[];
   entities: EntitySchema[];
   components: ComponentSchema[];
 }
@@ -138,15 +143,15 @@ export interface SceneFile extends HierarchyFile {
     background: {
       mode: BackgroundMode;
       color: Vec4Tuple;
-      texture?: AssetRef;
+      texture?: number;
       textureFillMode?: BackgroundTextureFillMode;
-      skyMesh?: AssetRef;
-      skyMaterial?: AssetRef;
+      skyMesh?: number;
+      skyMaterial?: number;
     };
     ambient?: {
       diffuseMode: DiffuseMode;
-      ambientLight?: AssetRef;
-      customAmbientLight?: AssetRef;
+      ambientLight?: number;
+      customAmbientLight?: number;
       diffuseSolidColor?: Vec4Tuple;
       diffuseIntensity: number;
       specularIntensity: number;

--- a/packages/loader/src/scene-format/types.ts
+++ b/packages/loader/src/scene-format/types.ts
@@ -66,14 +66,19 @@ export interface EntityPropOverride extends EntityOverrideProps {
   path: number[];
 }
 
+export interface ComponentSelector {
+  type: string;
+  index: number;
+}
+
 export interface ComponentOverride extends MutationBlock {
   path: number[];
-  selector: string;
+  selector: ComponentSelector;
 }
 
 export interface RemovedComponentOverride {
   path: number[];
-  selectors: string[];
+  selectors: ComponentSelector[];
 }
 
 export interface InstanceOverrides {

--- a/tests/src/loader/PrefabBenchmark.test.ts
+++ b/tests/src/loader/PrefabBenchmark.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { WebGLEngine } from "@galacean/engine-rhi-webgl";
+import { Loader, MeshRenderer } from "@galacean/engine-core";
+import { PrefabParser } from "../../../packages/loader/src/prefab/PrefabParser";
+import type { PrefabFile, NormalEntitySchema, ComponentSchema } from "../../../packages/loader/src/scene-format/types";
+
+let engine: WebGLEngine;
+
+Loader.registerClass("MeshRenderer", MeshRenderer);
+
+beforeAll(async () => {
+  const canvas = document.createElement("canvas");
+  canvas.width = 256;
+  canvas.height = 256;
+  engine = await WebGLEngine.create({ canvas });
+});
+
+afterAll(() => {
+  engine?.destroy();
+});
+
+// ---------------------------------------------------------------------------
+// Data generators
+// ---------------------------------------------------------------------------
+
+function generateTree(
+  depth: number,
+  branching: number
+): { entities: NormalEntitySchema[]; components: ComponentSchema[]; leafPaths: number[][] } {
+  const entities: NormalEntitySchema[] = [];
+  const components: ComponentSchema[] = [];
+  const leafPaths: number[][] = [];
+
+  function addNode(currentDepth: number, pathFromRoot: number[]): number {
+    const idx = entities.length;
+    const isLeaf = currentDepth >= depth;
+
+    if (isLeaf) {
+      const compIdx = components.length;
+      components.push({ type: "MeshRenderer" });
+      entities.push({ name: `node_${idx}`, components: [compIdx] });
+      leafPaths.push([...pathFromRoot]);
+    } else {
+      entities.push({ name: `node_${idx}` });
+      const childIndices: number[] = [];
+      for (let i = 0; i < branching; i++) {
+        const childIdx = addNode(currentDepth + 1, [...pathFromRoot, i]);
+        childIndices.push(childIdx);
+      }
+      entities[idx] = { ...entities[idx], children: childIndices };
+    }
+    return idx;
+  }
+
+  addNode(0, []);
+  return { entities, components, leafPaths };
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark runner
+// ---------------------------------------------------------------------------
+
+async function benchmark(label: string, iterations: number, fn: () => Promise<void>): Promise<number> {
+  // warmup
+  for (let i = 0; i < 10; i++) await fn();
+
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    await fn();
+  }
+  const elapsed = performance.now() - start;
+  const avg = elapsed / iterations;
+  console.log(`[Benchmark] ${label}: ${iterations} iters, total=${elapsed.toFixed(1)}ms, avg=${avg.toFixed(3)}ms`);
+  return avg;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Prefab parse benchmark", () => {
+  const ITERATIONS = 50;
+
+  // ~3280 nodes
+  const LARGE_DEPTH = 7;
+  const LARGE_BRANCHING = 3;
+
+  it(`no overrides — large tree (depth=${LARGE_DEPTH}, branching=${LARGE_BRANCHING})`, async () => {
+    const { entities, components } = generateTree(LARGE_DEPTH, LARGE_BRANCHING);
+    console.log(`[Setup] Tree: ${entities.length} entities, ${components.length} components`);
+
+    const innerPrefabData: PrefabFile = { version: "2.0", entities, components, root: 0 };
+    const innerPrefab = await PrefabParser.parse(engine, "bench-large-inner.prefab", innerPrefabData);
+    // @ts-ignore
+    engine.resourceManager._objectPool["bench-large-inner.prefab"] = innerPrefab;
+
+    const outerPrefabData: PrefabFile = {
+      version: "2.0",
+      entities: [{ name: "outer", children: [1] }, { instance: { asset: { $ref: "bench-large-inner.prefab" } } }],
+      components: [],
+      root: 0
+    };
+
+    try {
+      const avg = await benchmark(`No overrides (${entities.length} nodes)`, ITERATIONS, async () => {
+        const prefab = await PrefabParser.parse(engine, `b-no-${Math.random()}.prefab`, outerPrefabData);
+        const instance = prefab.instantiate();
+        instance.destroy();
+      });
+      expect(avg).toBeGreaterThan(0);
+    } finally {
+      // @ts-ignore
+      delete engine.resourceManager._objectPool["bench-large-inner.prefab"];
+    }
+  });
+
+  it(`with 50 overrides — large tree (depth=${LARGE_DEPTH}, branching=${LARGE_BRANCHING})`, async () => {
+    const { entities, components, leafPaths } = generateTree(LARGE_DEPTH, LARGE_BRANCHING);
+
+    const innerPrefabData: PrefabFile = { version: "2.0", entities, components, root: 0 };
+    const innerPrefab = await PrefabParser.parse(engine, "bench-large-ov.prefab", innerPrefabData);
+    // @ts-ignore
+    engine.resourceManager._objectPool["bench-large-ov.prefab"] = innerPrefab;
+
+    const overrideLeaves = leafPaths.slice(0, 50);
+    const outerPrefabData: PrefabFile = {
+      version: "2.0",
+      entities: [
+        { name: "outer", children: [1] },
+        {
+          instance: {
+            asset: { $ref: "bench-large-ov.prefab" },
+            overrides: {
+              entityProps: [
+                { path: [], name: "overriddenRoot" },
+                ...overrideLeaves.slice(0, 20).map((path) => ({ path, name: "renamed", isActive: false }))
+              ],
+              componentProps: overrideLeaves.map((path) => ({
+                path,
+                selector: { type: "MeshRenderer", index: 0 },
+                props: { enabled: false }
+              }))
+            }
+          }
+        }
+      ],
+      components: [],
+      root: 0
+    };
+
+    try {
+      const avg = await benchmark(`With 50 overrides (${entities.length} nodes)`, ITERATIONS, async () => {
+        const prefab = await PrefabParser.parse(engine, `b-ov-${Math.random()}.prefab`, outerPrefabData);
+        const instance = prefab.instantiate();
+        instance.destroy();
+      });
+      expect(avg).toBeGreaterThan(0);
+    } finally {
+      // @ts-ignore
+      delete engine.resourceManager._objectPool["bench-large-ov.prefab"];
+    }
+  });
+});

--- a/tests/src/loader/PrefabBenchmark.test.ts
+++ b/tests/src/loader/PrefabBenchmark.test.ts
@@ -89,14 +89,15 @@ describe("Prefab parse benchmark", () => {
     const { entities, components } = generateTree(LARGE_DEPTH, LARGE_BRANCHING);
     console.log(`[Setup] Tree: ${entities.length} entities, ${components.length} components`);
 
-    const innerPrefabData: PrefabFile = { version: "2.0", entities, components, root: 0 };
+    const innerPrefabData: PrefabFile = { version: "2.0", refs: [], entities, components, root: 0 };
     const innerPrefab = await PrefabParser.parse(engine, "bench-large-inner.prefab", innerPrefabData);
     // @ts-ignore
     engine.resourceManager._objectPool["bench-large-inner.prefab"] = innerPrefab;
 
     const outerPrefabData: PrefabFile = {
       version: "2.0",
-      entities: [{ name: "outer", children: [1] }, { instance: { asset: { $ref: "bench-large-inner.prefab" } } }],
+      refs: [{ url: "bench-large-inner.prefab" }],
+      entities: [{ name: "outer", children: [1] }, { instance: { asset: 0 } }],
       components: [],
       root: 0
     };
@@ -117,7 +118,7 @@ describe("Prefab parse benchmark", () => {
   it(`with 50 overrides — large tree (depth=${LARGE_DEPTH}, branching=${LARGE_BRANCHING})`, async () => {
     const { entities, components, leafPaths } = generateTree(LARGE_DEPTH, LARGE_BRANCHING);
 
-    const innerPrefabData: PrefabFile = { version: "2.0", entities, components, root: 0 };
+    const innerPrefabData: PrefabFile = { version: "2.0", refs: [], entities, components, root: 0 };
     const innerPrefab = await PrefabParser.parse(engine, "bench-large-ov.prefab", innerPrefabData);
     // @ts-ignore
     engine.resourceManager._objectPool["bench-large-ov.prefab"] = innerPrefab;
@@ -125,11 +126,12 @@ describe("Prefab parse benchmark", () => {
     const overrideLeaves = leafPaths.slice(0, 50);
     const outerPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [{ url: "bench-large-ov.prefab" }],
       entities: [
         { name: "outer", children: [1] },
         {
           instance: {
-            asset: { $ref: "bench-large-ov.prefab" },
+            asset: 0,
             overrides: {
               entityProps: [
                 { path: [], name: "overriddenRoot" },

--- a/tests/src/loader/PrefabResource.test.ts
+++ b/tests/src/loader/PrefabResource.test.ts
@@ -38,6 +38,7 @@ describe("PrefabResource refCount", () => {
   it("should reject prefab data with an unsupported version", () => {
     const prefabData = {
       version: "1.0",
+      refs: [],
       entities: [{ name: "root" }],
       components: [],
       root: 0
@@ -51,6 +52,7 @@ describe("PrefabResource refCount", () => {
   it("should increase and decrease with instantiated entities", async () => {
     const prefabData: PrefabFile = {
       version: "2.0",
+      refs: [],
       entities: [{ name: "root", children: [1] }, { name: "child" }],
       components: [],
       root: 0
@@ -76,6 +78,7 @@ describe("PrefabResource refCount", () => {
   it("should support destroy then re-instantiate cycle", async () => {
     const prefabData: PrefabFile = {
       version: "2.0",
+      refs: [],
       entities: [{ name: "root", children: [1] }, { name: "child" }],
       components: [],
       root: 0
@@ -108,6 +111,7 @@ describe("PrefabResource refCount", () => {
   it("should count instances when prefab root comes from a nested prefab instance", async () => {
     const nestedPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [],
       entities: [{ name: "nestedRoot", children: [1] }, { name: "nestedChild" }],
       components: [],
       root: 0
@@ -119,7 +123,8 @@ describe("PrefabResource refCount", () => {
     try {
       const outerPrefabData: PrefabFile = {
         version: "2.0",
-        entities: [{ instance: { asset: { $ref: "nested-root-instance.prefab" } } }],
+        refs: [{ url: "nested-root-instance.prefab" }],
+        entities: [{ instance: { asset: 0 } }],
         components: [],
         root: 0
       };
@@ -149,8 +154,9 @@ describe("$ref null guard in Prefab mode", () => {
   it("should not add null to dependence assets when $ref resolves to null", async () => {
     const prefabData: PrefabFile = {
       version: "2.0",
+      refs: [{ url: "missing-asset.png" }],
       entities: [{ name: "root", components: [0] }],
-      components: [{ type: "DiceScript", props: { skinMesh: { $ref: "missing-asset.png" } } }],
+      components: [{ type: "DiceScript", props: { skinMesh: { $ref: 0 } } }],
       root: 0
     };
 
@@ -171,6 +177,7 @@ describe("Prefab instance overrides", () => {
     // Nested prefab: root → child
     const nestedPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [],
       entities: [{ name: "originalRoot", children: [1] }, { name: "originalChild" }],
       components: [],
       root: 0
@@ -182,11 +189,12 @@ describe("Prefab instance overrides", () => {
     // Outer prefab with instance overrides: rename child entity
     const outerPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [{ url: "nested.prefab" }],
       entities: [
         { name: "outerRoot", children: [1] },
         {
           instance: {
-            asset: { $ref: "nested.prefab" },
+            asset: 0,
             overrides: {
               entityProps: [
                 { path: [], name: "renamedRoot" },
@@ -216,6 +224,7 @@ describe("Prefab instance overrides", () => {
   it("should override component props via componentProps", async () => {
     const nestedPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [],
       entities: [{ name: "root", components: [0] }],
       components: [{ type: "MeshRenderer" }],
       root: 0
@@ -226,11 +235,12 @@ describe("Prefab instance overrides", () => {
 
     const outerPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [{ url: "nested-cp.prefab" }],
       entities: [
         { name: "outerRoot", children: [1] },
         {
           instance: {
-            asset: { $ref: "nested-cp.prefab" },
+            asset: 0,
             overrides: {
               componentProps: [{ path: [], selector: { type: "MeshRenderer", index: 0 }, props: { enabled: false } }]
             }
@@ -256,6 +266,7 @@ describe("Prefab instance overrides", () => {
   it("should execute component override calls after props", async () => {
     const nestedPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [],
       entities: [{ name: "root", components: [0] }],
       components: [{ type: "OverrideCallScript" }],
       root: 0
@@ -266,11 +277,12 @@ describe("Prefab instance overrides", () => {
 
     const outerPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [{ url: "nested-calls.prefab" }],
       entities: [
         { name: "outerRoot", children: [1] },
         {
           instance: {
-            asset: { $ref: "nested-calls.prefab" },
+            asset: 0,
             overrides: {
               componentProps: [
                 {
@@ -303,6 +315,7 @@ describe("Prefab instance overrides", () => {
   it("should add components via addedComponents", async () => {
     const nestedPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [],
       entities: [{ name: "root" }],
       components: [],
       root: 0
@@ -313,11 +326,12 @@ describe("Prefab instance overrides", () => {
 
     const outerPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [{ url: "nested-ac.prefab" }],
       entities: [
         { name: "outerRoot", children: [1] },
         {
           instance: {
-            asset: { $ref: "nested-ac.prefab" },
+            asset: 0,
             overrides: {
               addedComponents: [
                 {
@@ -353,6 +367,7 @@ describe("Prefab instance overrides", () => {
   it("should add entities via addedEntities", async () => {
     const nestedPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [],
       entities: [{ name: "root" }],
       components: [],
       root: 0
@@ -363,11 +378,12 @@ describe("Prefab instance overrides", () => {
 
     const outerPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [{ url: "nested-ae.prefab" }],
       entities: [
         { name: "outerRoot", children: [1] },
         {
           instance: {
-            asset: { $ref: "nested-ae.prefab" },
+            asset: 0,
             overrides: {
               addedEntities: [
                 {
@@ -413,6 +429,7 @@ describe("Prefab instance overrides", () => {
   it("should remove entities via removedEntities", async () => {
     const nestedPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [],
       entities: [{ name: "root", children: [1] }, { name: "child" }],
       components: [],
       root: 0
@@ -423,11 +440,12 @@ describe("Prefab instance overrides", () => {
 
     const outerPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [{ url: "nested-re.prefab" }],
       entities: [
         { name: "outerRoot", children: [1] },
         {
           instance: {
-            asset: { $ref: "nested-re.prefab" },
+            asset: 0,
             overrides: {
               removedEntities: [[0]]
             }
@@ -452,6 +470,7 @@ describe("Prefab instance overrides", () => {
   it("should remove components via removedComponents", async () => {
     const nestedPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [],
       entities: [{ name: "root", components: [0] }],
       components: [{ type: "MeshRenderer" }],
       root: 0
@@ -462,11 +481,12 @@ describe("Prefab instance overrides", () => {
 
     const outerPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [{ url: "nested-rc.prefab" }],
       entities: [
         { name: "outerRoot", children: [1] },
         {
           instance: {
-            asset: { $ref: "nested-rc.prefab" },
+            asset: 0,
             overrides: {
               removedComponents: [{ path: [], selectors: [{ type: "MeshRenderer", index: 0 }] }]
             }
@@ -495,6 +515,7 @@ describe("Cross-prefab $component ref", () => {
     // 1. nested prefab (dice.prefab): single root entity with MeshRenderer
     const nestedPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [],
       entities: [{ name: "diceRoot", components: [0] }],
       components: [{ type: "MeshRenderer" }],
       root: 0
@@ -508,11 +529,12 @@ describe("Cross-prefab $component ref", () => {
     //    Entity 1: dice (nested prefab instance)
     const outerPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [{ url: "dice.prefab" }],
       entities: [
         { name: "DiceNode", children: [1], components: [0] },
         {
           instance: {
-            asset: { $ref: "dice.prefab" },
+            asset: 0,
             overrides: { entityProps: [{ path: [], name: "dice" }] }
           }
         }
@@ -545,6 +567,7 @@ describe("Cross-prefab $component ref", () => {
   it("should resolve both local and cross-prefab refs, and survive clone independently", async () => {
     const nestedPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [],
       entities: [{ name: "diceRoot", components: [0] }],
       components: [{ type: "MeshRenderer" }],
       root: 0
@@ -558,12 +581,13 @@ describe("Cross-prefab $component ref", () => {
     // Entity 2: dice — nested prefab instance
     const outerPrefabData: PrefabFile = {
       version: "2.0",
+      refs: [{ url: "dice.prefab" }],
       entities: [
         { name: "DiceNode", children: [1, 2], components: [0] },
         { name: "numCube", components: [1] },
         {
           instance: {
-            asset: { $ref: "dice.prefab" },
+            asset: 0,
             overrides: { entityProps: [{ path: [], name: "dice" }] }
           }
         }

--- a/tests/src/loader/PrefabResource.test.ts
+++ b/tests/src/loader/PrefabResource.test.ts
@@ -264,7 +264,7 @@ describe("Prefab instance overrides", () => {
           instance: {
             asset: { $ref: "nested-cp.prefab" },
             overrides: {
-              componentProps: [{ path: [], selector: "MeshRenderer/0", props: { enabled: false } }]
+              componentProps: [{ path: [], selector: { type: "MeshRenderer", index: 0 }, props: { enabled: false } }]
             }
           }
         }
@@ -307,7 +307,7 @@ describe("Prefab instance overrides", () => {
               componentProps: [
                 {
                   path: [],
-                  selector: "OverrideCallScript/0",
+                  selector: { type: "OverrideCallScript", index: 0 },
                   props: { value: "base" },
                   calls: [{ method: "appendSuffix", args: ["-override"] }]
                 }
@@ -500,7 +500,7 @@ describe("Prefab instance overrides", () => {
           instance: {
             asset: { $ref: "nested-rc.prefab" },
             overrides: {
-              removedComponents: [{ path: [], selectors: ["MeshRenderer/0"] }]
+              removedComponents: [{ path: [], selectors: [{ type: "MeshRenderer", index: 0 }] }]
             }
           }
         }

--- a/tests/src/loader/PrefabResource.test.ts
+++ b/tests/src/loader/PrefabResource.test.ts
@@ -167,38 +167,6 @@ describe("$ref null guard in Prefab mode", () => {
 });
 
 describe("Prefab instance overrides", () => {
-  it("should reject direct root props on prefab instance entities", async () => {
-    const nestedPrefabData: PrefabFile = {
-      version: "2.0",
-      entities: [{ name: "nestedRoot" }],
-      components: [],
-      root: 0
-    };
-    const nestedPrefab = await PrefabParser.parse(engine, "nested-invalid.prefab", nestedPrefabData);
-    // @ts-ignore
-    engine.resourceManager._objectPool["nested-invalid.prefab"] = nestedPrefab;
-
-    const invalidPrefabData = {
-      version: "2.0",
-      entities: [
-        { name: "outerRoot", children: [1] },
-        {
-          name: "invalidRootName",
-          instance: { asset: { $ref: "nested-invalid.prefab" } }
-        }
-      ],
-      components: [],
-      root: 0
-    } as any;
-
-    expect(() => PrefabParser.parse(engine, "invalid-instance.prefab", invalidPrefabData)).toThrow(
-      "Prefab instance entity cannot declare name directly. Move root overrides to instance.overrides.entityProps with path: []."
-    );
-
-    // @ts-ignore
-    delete engine.resourceManager._objectPool["nested-invalid.prefab"];
-  });
-
   it("should apply entityProps overrides to nested prefab entities", async () => {
     // Nested prefab: root → child
     const nestedPrefabData: PrefabFile = {

--- a/tests/src/loader/SceneFormatV2.test.ts
+++ b/tests/src/loader/SceneFormatV2.test.ts
@@ -500,7 +500,7 @@ describe("SceneParser v2 entity tree", () => {
               componentProps: [
                 {
                   path: [],
-                  selector: "MeshRenderer/0",
+                  selector: { type: "MeshRenderer", index: 0 },
                   calls: [
                     {
                       method: "setMaterial",

--- a/tests/src/loader/SceneFormatV2.test.ts
+++ b/tests/src/loader/SceneFormatV2.test.ts
@@ -87,7 +87,7 @@ describe("ReflectionParser v2 props resolution", () => {
   it("should resolve primitive values directly", async () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
     const target: any = {};
     await parser.parseProps(target, {
       name: "test",
@@ -102,7 +102,7 @@ describe("ReflectionParser v2 props resolution", () => {
   it("should resolve nested plain objects recursively", async () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
     const target: any = {};
     await parser.parseProps(target, {
       nested: { a: 1, b: { c: 2 } }
@@ -113,7 +113,7 @@ describe("ReflectionParser v2 props resolution", () => {
   it("should modify existing object properties in place", async () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
     const original = { x: 0, y: 0, z: 0 };
     const target: any = { position: original };
     await parser.parseProps(target, {
@@ -129,7 +129,7 @@ describe("ReflectionParser v2 props resolution", () => {
   it("should resolve arrays recursively", async () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
     const target: any = {};
     await parser.parseProps(target, {
       items: [1, "two", { key: 3 }]
@@ -145,7 +145,7 @@ describe("ReflectionParser v2 props resolution", () => {
     context.entityMap.set(0, entity0);
     context.entityMap.set(1, entity1);
 
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
     const target: any = {};
     await parser.parseProps(target, {
       target: { $entity: 1 }
@@ -156,7 +156,7 @@ describe("ReflectionParser v2 props resolution", () => {
   it("should resolve missing $entity to null", async () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
     const target: any = {};
     await parser.parseProps(target, {
       target: { $entity: 999 }
@@ -170,7 +170,7 @@ describe("ReflectionParser v2 props resolution", () => {
     const entity = new Entity(engine, "test");
     context.entityMap.set(0, entity);
 
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
     const target: any = {};
     await parser.parseProps(target, {
       comp: { $component: { entity: 0, type: "Transform", index: 0 } }
@@ -194,7 +194,8 @@ describe("ReflectionParser calls resolution", () => {
     const getResourceByRef = vi
       .spyOn(engine.resourceManager as any, "getResourceByRef")
       .mockResolvedValue(asset as any);
-    const parser = new ReflectionParser(context);
+    const refs = [{ url: "call-asset" }];
+    const parser = new ReflectionParser(context, refs);
     const target = new CallOrderComponent(new Entity(engine, "host"));
 
     try {
@@ -202,7 +203,7 @@ describe("ReflectionParser calls resolution", () => {
         {
           method: "captureResolvedArgs",
           args: [
-            { $ref: "call-asset" },
+            { $ref: 0 },
             { $type: "TestValueType", x: 3, y: 4 },
             { $entity: 1 },
             { $component: { entity: 1, type: "Transform", index: 0 } }
@@ -224,7 +225,7 @@ describe("ReflectionParser calls resolution", () => {
   it("should apply result props and nested calls", async () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
     const target = new CallOrderComponent(new Entity(engine, "host"));
 
     await parser.parseCalls(target, [
@@ -245,7 +246,7 @@ describe("ReflectionParser calls resolution", () => {
   it("should await each call before executing the next one", async () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
     const target = new CallOrderComponent(new Entity(engine, "host"));
 
     await parser.parseCalls(target, [
@@ -259,7 +260,7 @@ describe("ReflectionParser calls resolution", () => {
   it("should throw a clear error when the target method is missing", async () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
     const target: any = {};
 
     await expect(parser.parseCalls(target, [{ method: "missingMethod" }])).rejects.toThrow("missingMethod");
@@ -274,10 +275,12 @@ describe("SceneParser v2 entity tree", () => {
   function createSceneData(
     entities: SceneFile["entities"],
     components: SceneFile["components"],
-    rootEntities: number[]
+    rootEntities: number[],
+    refs: SceneFile["refs"] = []
   ): SceneFile {
     return {
       version: "2.0",
+      refs,
       entities,
       components,
       scene: {
@@ -313,7 +316,7 @@ describe("SceneParser v2 entity tree", () => {
     const context = new ParserContext(engine, ParserType.Scene, scene);
 
     expect(() => new SceneParser(data, context, scene)).toThrow(
-      'Unsupported scene format version "missing". Expected "2.0".'
+      'Unsupported scene format version "undefined". Expected "2.0".'
     );
   });
 
@@ -488,75 +491,17 @@ describe("SceneParser v2 entity tree", () => {
     await expect(parser.promise).rejects.toThrow("UnregisteredComponent999");
   });
 
-  it("should collect dependent assets from component calls and override calls", () => {
+  it("should collect dependent assets from refs array", () => {
     const data: SceneFile = {
       version: "2.0",
-      entities: [
-        { name: "Root", components: [0], children: [1] },
-        {
-          instance: {
-            asset: { $ref: "nested.prefab" },
-            overrides: {
-              componentProps: [
-                {
-                  path: [],
-                  selector: { type: "MeshRenderer", index: 0 },
-                  calls: [
-                    {
-                      method: "setMaterial",
-                      args: [{ $ref: "override-call.mat" }],
-                      result: {
-                        props: {
-                          nested: { $ref: "override-result.mat" }
-                        }
-                      }
-                    }
-                  ]
-                }
-              ],
-              addedComponents: [
-                {
-                  target: [],
-                  component: {
-                    type: "CallOrderComponent",
-                    calls: [{ method: "captureResolvedArgs", args: [{ $ref: "added-component.mat" }] }]
-                  } as any
-                }
-              ],
-              addedEntities: [
-                {
-                  parent: [],
-                  entity: {
-                    name: "Inline",
-                    components: [
-                      {
-                        type: "CallOrderComponent",
-                        calls: [{ method: "captureResolvedArgs", args: [{ $ref: "inline-component.mat" }] }]
-                      } as any
-                    ]
-                  }
-                }
-              ]
-            } as any
-          }
-        }
+      refs: [
+        { url: "nested.prefab" },
+        { url: "component-call.mat" },
+        { url: "override-call.mat" },
+        { url: "texture.png", key: "mipmap" }
       ],
-      components: [
-        {
-          type: "CallOrderComponent",
-          calls: [
-            {
-              method: "captureResolvedArgs",
-              args: [{ $ref: "component-call.mat" }],
-              result: {
-                props: {
-                  linked: { $ref: "component-result.mat" }
-                }
-              }
-            }
-          ]
-        } as any
-      ],
+      entities: [{ name: "Root", components: [0] }],
+      components: [{ type: "CallOrderComponent" }],
       scene: {
         entities: [0],
         background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] },
@@ -577,22 +522,21 @@ describe("SceneParser v2 entity tree", () => {
       .spyOn(engine.resourceManager as any, "getResourceByRef")
       .mockResolvedValue({ _addReferCount() {} } as any);
 
-    let refs: string[];
+    let collectedRefs: Array<{ $ref: string; key?: string }>;
     try {
       parser._collectDependentAssets(data);
-      refs = getResourceByRef.mock.calls.map((args) => (args[0] as any).$ref);
+      collectedRefs = getResourceByRef.mock.calls.map((args) => args[0] as any);
     } finally {
       getResourceByRef.mockRestore();
     }
-    expect(refs).to.include.members([
+    expect(collectedRefs).to.have.length(4);
+    expect(collectedRefs.map((r) => r.$ref)).to.deep.equal([
       "nested.prefab",
       "component-call.mat",
-      "component-result.mat",
       "override-call.mat",
-      "override-result.mat",
-      "added-component.mat",
-      "inline-component.mat"
+      "texture.png"
     ]);
+    expect(collectedRefs[3].key).to.equal("mipmap");
   });
 });
 
@@ -609,7 +553,7 @@ describe("ReflectionParser $signal resolution", () => {
     context.entityMap.set(0, entity0);
     context.entityMap.set(1, entity1);
 
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
 
     const bound: Array<{ target: any; method: string; args: any[] }> = [];
     const mockSignal = {
@@ -640,7 +584,7 @@ describe("ReflectionParser $signal resolution", () => {
     context.entityMap.set(0, entity0);
     // entity 1 does NOT exist in entityMap
 
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
 
     const bound: any[] = [];
     const mockSignal = {
@@ -669,7 +613,7 @@ describe("ReflectionParser $signal resolution", () => {
     context.entityMap.set(0, entity0);
     context.entityMap.set(1, entity1);
 
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
 
     // onClick is undefined — not initialized as a Signal
     const target: any = { onClick: undefined };
@@ -688,7 +632,7 @@ describe("ReflectionParser $signal resolution", () => {
     const entity = new Entity(engine, "test");
     context.entityMap.set(0, entity);
 
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
     const target: any = {};
     await parser.parseProps(target, {
       comp: { $component: { entity: 0, type: "NonExistentType999", index: 0 } }
@@ -705,7 +649,7 @@ describe("ReflectionParser $type resolution", () => {
   it("should construct $type instance and apply remaining props", async () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
     const target: any = {};
     await parser.parseProps(target, {
       value: { $type: "TestValueType", x: 10, y: 20 }
@@ -718,7 +662,7 @@ describe("ReflectionParser $type resolution", () => {
   it("should construct $type instance without props", async () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
     const target: any = {};
     await parser.parseProps(target, {
       value: { $type: "TestValueType" }
@@ -731,7 +675,7 @@ describe("ReflectionParser $type resolution", () => {
   it("should throw a clear error when $type references an unregistered class", async () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
-    const parser = new ReflectionParser(context);
+    const parser = new ReflectionParser(context, []);
     const target: any = {};
     await expect(
       parser.parseProps(target, {
@@ -770,6 +714,7 @@ describe("applySceneData scene property parsing", () => {
         }
       });
 
+    const refs = [{ url: "custom-ambient" }, { url: "ambient-light" }];
     try {
       await applySceneData(
         scene,
@@ -781,11 +726,12 @@ describe("applySceneData scene property parsing", () => {
             diffuseIntensity: 1,
             specularIntensity: 1,
             specularMode: SpecularMode.Custom,
-            customAmbientLight: { $ref: "custom-ambient" },
-            ambientLight: { $ref: "ambient-light" }
+            customAmbientLight: 0,
+            ambientLight: 1
           }
         },
-        engine.resourceManager
+        engine.resourceManager,
+        refs
       );
     } finally {
       getResourceByRef.mockRestore();
@@ -813,6 +759,7 @@ describe("applySceneData scene property parsing", () => {
         }
       });
 
+    const refs = [{ url: "sky-mesh" }, { url: "sky-material" }];
     try {
       await applySceneData(
         scene,
@@ -821,11 +768,12 @@ describe("applySceneData scene property parsing", () => {
           background: {
             mode: BackgroundMode.Sky,
             color: [0, 0, 0, 1],
-            skyMesh: { $ref: "sky-mesh" },
-            skyMaterial: { $ref: "sky-material" }
+            skyMesh: 0,
+            skyMaterial: 1
           }
         },
-        engine.resourceManager
+        engine.resourceManager,
+        refs
       );
     } finally {
       getResourceByRef.mockRestore();
@@ -847,6 +795,7 @@ describe("applySceneData scene property parsing", () => {
         return Promise.resolve(null) as any;
       });
 
+    const refs = [{ url: "background-texture" }];
     try {
       await applySceneData(
         scene,
@@ -855,11 +804,12 @@ describe("applySceneData scene property parsing", () => {
           background: {
             mode: BackgroundMode.Texture,
             color: [0, 0, 0, 1],
-            texture: { $ref: "background-texture" },
+            texture: 0,
             textureFillMode: BackgroundTextureFillMode.Fill
           }
         },
-        engine.resourceManager
+        engine.resourceManager,
+        refs
       );
     } finally {
       getResourceByRef.mockRestore();
@@ -887,7 +837,8 @@ describe("applySceneData scene property parsing", () => {
           shadowFadeBorder: 0.2
         }
       },
-      engine.resourceManager
+      engine.resourceManager,
+      []
     );
 
     expect(scene.castShadows).to.equal(false);
@@ -917,7 +868,8 @@ describe("applySceneData scene property parsing", () => {
           fogColor: [1, 0, 0, 1]
         }
       },
-      engine.resourceManager
+      engine.resourceManager,
+      []
     );
 
     expect(scene.fogMode).to.equal(FogMode.ExponentialSquared);
@@ -948,7 +900,8 @@ describe("applySceneData scene property parsing", () => {
           minHorizonAngle: 0.04
         }
       },
-      engine.resourceManager
+      engine.resourceManager,
+      []
     );
 
     const ao = scene.ambientOcclusion;
@@ -973,7 +926,8 @@ describe("applySceneData scene property parsing", () => {
           color: [0.5, 0.6, 0.7, 1]
         }
       },
-      engine.resourceManager
+      engine.resourceManager,
+      []
     );
 
     expect(scene.background.mode).to.equal(BackgroundMode.SolidColor);
@@ -991,7 +945,8 @@ describe("applySceneData scene property parsing", () => {
         entities: [0],
         background: { mode: BackgroundMode.SolidColor, color: [0, 0, 0, 1] }
       },
-      engine.resourceManager
+      engine.resourceManager,
+      []
     );
 
     expect(scene.castShadows).to.equal(true);


### PR DESCRIPTION
## 概要

在 PR #2959 基础上优化 prefab instance 的 override 解析机制，**净减 99 行代码**。

### 核心改造：预构建缓存 → 实时查找

原方案加载 prefab instance 时，无条件调用 `_walkPrefabTree` 遍历整棵实例树，构建两个 Map（entity path → Entity, component key → Component）。即使没有任何 override 也要完整遍历 + 字符串拼接 + Map 插入。对大型 glTF 模型（几百个骨骼节点）浪费明显。

改为按需查找：
- `_resolveEntity`：`children[idx]` 逐级定位，无 override 时零开销
- `_resolveComponent`：`getComponents(Class, buffer)[index]` 定位，复用静态 buffer

### 其他优化

- **ComponentSelector 结构化**：从字符串 `"MeshRenderer/0"` 改为 `{ type, index }`，消除运行时字符串拆解
- **合并 stage**：`_parseComponentsProps` + `_parseComponentsCalls` 合为单次遍历
- **移除 dedupKey**：去掉 componentProps 运行时去重（编辑器保证无重复）
- **移除防御性校验**：`_assertPrefabInstanceEntityShape` 及 null 检查，运行时信任协议数据
- **buffer 复用**：`HierarchyParser` 和 `ReflectionParser` 共用静态 `Component[]` buffer
- **命名统一**：`$signal` listener 的 `arguments` 改为 `args`，与 `CallSpec.args` 保持一致

### 改动文件

| 文件 | 变更 |
|------|------|
| `HierarchyParser.ts` | 删除预构建缓存相关代码，新增 `_resolveEntity`/`_resolveComponent`，合并 props+calls stage，移除防御校验 |
| `ParserContext.ts` | 删除 `PrefabInstanceContext` 接口 |
| `ReflectionParser.ts` | `_resolveComponent` 复用静态 buffer，`$signal` listener `arguments` → `args` |
| `types.ts` | 新增 `ComponentSelector` 接口 |
| 测试文件 | selector 格式同步更新，删除 assert 校验测试 |

### Benchmark（3280 节点树，50 轮）

| 场景 | 原始代码 | 改造后 | 提升 |
|------|---------|--------|------|
| 无 override | 113.6ms | 106.9ms | **+5.9%** |
| 50 override | 141.9ms | 139.9ms | **+1.5%** |

- 无 override 场景提升最明显：原方案仍需遍历 3280 节点建 Map，改造后零开销
- 有 override 场景也有正向收益：省掉全量建 Map 的开销 > 按需 `children[idx]` 查找的额外成本
- override 数量增多不会退化：每次 resolve 只走目标路径（O(depth)），不遍历全树

## 测试
- [x] PrefabResource — 14 passed
- [x] SceneFormatV2 — 37 passed
- [x] PrefabBenchmark — 2 passed
