### PR TITLE
refactor(loader): protocol consistency + honest types + quality cleanup

### DIFF
--- a/packages/core/src/asset/ResourceManager.ts
+++ b/packages/core/src/asset/ResourceManager.ts
@@ -576,25 +576,25 @@ export class ResourceManager {
    * @internal
    * @beta Just for internal editor, not recommended for developers.
    */
-  getResourceByRef<T extends EngineObject>(ref: { $ref: string; key?: string; isClone?: boolean }): AssetPromise<T> {
-    const { $ref, key, isClone } = ref;
-    if (!$ref) {
-      Logger.warn("ResourceManager.getResourceByRef: $ref is empty.");
+  getResourceByRef<T extends EngineObject>(ref: { url: string; key?: string; isClone?: boolean }): AssetPromise<T> {
+    const { url, key, isClone } = ref;
+    if (!url) {
+      Logger.warn("ResourceManager.getResourceByRef: url is empty.");
       return AssetPromise.resolve(null);
     }
 
-    const cached = this._objectPool[$ref];
+    const cached = this._objectPool[url];
     if (cached) {
       return AssetPromise.resolve(isClone ? <T>(<IClone>(<unknown>cached)).clone() : cached);
     }
 
-    const mapped = this._virtualPathResourceMap[$ref];
+    const mapped = this._virtualPathResourceMap[url];
     if (!mapped) {
-      Logger.warn(`ResourceManager.getResourceByRef: $ref "${$ref}" not found in virtualPathResourceMap.`);
+      Logger.warn(`ResourceManager.getResourceByRef: url "${url}" not found in virtualPathResourceMap.`);
       return AssetPromise.resolve(null);
     }
 
-    const loadUrl = key ? $ref + "?q=" + key : $ref;
+    const loadUrl = key ? url + "?q=" + key : url;
     const promise = this.load<T>({ url: loadUrl, type: mapped.type, params: mapped.params });
     return isClone ? promise.then((item) => <T>(<IClone>(<unknown>item)).clone()) : promise;
   }

--- a/packages/loader/src/AnimationClipLoader.ts
+++ b/packages/loader/src/AnimationClipLoader.ts
@@ -45,7 +45,7 @@ class AnimationClipLoader extends Loader<AnimationClip> {
   private _parseKeyframeValue(keyframe: any, resourceManager: ResourceManager): Promise<any> {
     const value = keyframe.value;
 
-    if (typeof value === "object" && (value as any)?.$ref) {
+    if (typeof value === "object" && (value as any)?.url) {
       return new Promise((resolve) => {
         resourceManager
           // @ts-ignore

--- a/packages/loader/src/MaterialLoader.ts
+++ b/packages/loader/src/MaterialLoader.ts
@@ -11,7 +11,7 @@ import {
   resourceLoader
 } from "@galacean/engine-core";
 import { Color, Vector2, Vector3, Vector4 } from "@galacean/engine-math";
-import type { AssetRef } from "./schema/CommonSchema";
+import type { RefItem } from "./schema/CommonSchema";
 import {
   MaterialLoaderType,
   type IColor,
@@ -51,7 +51,7 @@ class MaterialLoader extends Loader<Material> {
             resolve(
               resourceManager
                 // @ts-ignore
-                .getResourceByRef<Shader>(<AssetRef>shaderRef)
+                .getResourceByRef<Shader>(<RefItem>shaderRef)
                 .then((shader) => this._getMaterialByShader(materialSchema, shader, engine))
             );
           }
@@ -99,7 +99,7 @@ class MaterialLoader extends Loader<Material> {
         case MaterialLoaderType.Texture:
           texturePromises.push(
             // @ts-ignore
-            engine.resourceManager.getResourceByRef<Texture2D>(<AssetRef>value).then((texture) => {
+            engine.resourceManager.getResourceByRef<Texture2D>(<RefItem>value).then((texture) => {
               materialShaderData.setTexture(key, texture);
             })
           );

--- a/packages/loader/src/SceneLoader.ts
+++ b/packages/loader/src/SceneLoader.ts
@@ -16,6 +16,12 @@ import type { RefItem } from "./schema/CommonSchema";
 import { SpecularMode, type SceneFile } from "./schema/SceneSchema";
 import { ParserContext, ParserType, SceneParser } from "./resource-deserialize";
 
+function loadRef<T>(refs: RefItem[], index: number, resourceManager: ResourceManager, label: string): Promise<T> {
+  const ref = resolveRefItem(refs, index, "SceneLoader", label);
+  // @ts-ignore
+  return resourceManager.getResourceByRef<T>({ $ref: ref.url, key: ref.key });
+}
+
 /**
  * Apply scene-level data (ambient, background, shadow, fog, AO) to a Scene.
  * @internal
@@ -26,7 +32,7 @@ export function applySceneData(
   resourceManager: ResourceManager,
   refs: RefItem[]
 ): Promise<void> {
-  const promises: Promise<any>[] = [];
+  const promises: Promise<unknown>[] = [];
 
   try {
     // parse ambient light
@@ -44,30 +50,28 @@ export function applySceneData(
       }
 
       if (useCustomAmbient && ambient.customAmbientLight != null) {
-        const ref = resolveRefItem(refs, ambient.customAmbientLight, "SceneLoader", "scene.ambient.customAmbientLight");
         promises.push(
-          resourceManager
-            // @ts-ignore
-            .getResourceByRef<any>({ $ref: ref.url, key: ref.key })
-            .then((ambientLight) => {
+          loadRef<any>(refs, ambient.customAmbientLight, resourceManager, "scene.ambient.customAmbientLight").then(
+            (ambientLight) => {
               scene.ambientLight.specularTexture = ambientLight?.specularTexture;
-            })
+            }
+          )
         );
       }
 
       if (ambient.ambientLight != null && (!useCustomAmbient || useSH)) {
-        const ref = resolveRefItem(refs, ambient.ambientLight, "SceneLoader", "scene.ambient.ambientLight");
         promises.push(
-          // @ts-ignore
-          resourceManager.getResourceByRef<any>({ $ref: ref.url, key: ref.key }).then((ambientLight) => {
-            if (!useCustomAmbient) {
-              scene.ambientLight.specularTexture = ambientLight?.specularTexture;
-            }
+          loadRef<any>(refs, ambient.ambientLight, resourceManager, "scene.ambient.ambientLight").then(
+            (ambientLight) => {
+              if (!useCustomAmbient) {
+                scene.ambientLight.specularTexture = ambientLight?.specularTexture;
+              }
 
-            if (useSH) {
-              scene.ambientLight.diffuseSphericalHarmonics = ambientLight?.diffuseSphericalHarmonics;
+              if (useSH) {
+                scene.ambientLight.diffuseSphericalHarmonics = ambientLight?.diffuseSphericalHarmonics;
+              }
             }
-          })
+          )
         );
       }
     }
@@ -84,35 +88,27 @@ export function applySceneData(
       }
       case BackgroundMode.Sky:
         if (background.skyMesh != null && background.skyMaterial != null) {
-          const meshRef = resolveRefItem(refs, background.skyMesh, "SceneLoader", "scene.background.skyMesh");
-          const matRef = resolveRefItem(refs, background.skyMaterial, "SceneLoader", "scene.background.skyMaterial");
-          const skyMeshPromise = resourceManager
-            // @ts-ignore
-            .getResourceByRef<Mesh>({ $ref: meshRef.url, key: meshRef.key })
-            .then((mesh) => {
+          promises.push(
+            loadRef<Mesh>(refs, background.skyMesh, resourceManager, "scene.background.skyMesh").then((mesh) => {
               scene.background.sky.mesh = mesh;
-            });
-          const skyMaterialPromise = resourceManager
-            // @ts-ignore
-            .getResourceByRef({ $ref: matRef.url, key: matRef.key })
-            .then((material) => {
-              scene.background.sky.material = material;
-            });
-          promises.push(skyMeshPromise, skyMaterialPromise);
+            }),
+            loadRef<any>(refs, background.skyMaterial, resourceManager, "scene.background.skyMaterial").then(
+              (material) => {
+                scene.background.sky.material = material;
+              }
+            )
+          );
         } else {
           Logger.warn("Sky background mode requires skyMesh and skyMaterial");
         }
         break;
       case BackgroundMode.Texture:
         if (background.texture != null) {
-          const texRef = resolveRefItem(refs, background.texture, "SceneLoader", "scene.background.texture");
-          const backgroundPromise = resourceManager
-            // @ts-ignore
-            .getResourceByRef<any>({ $ref: texRef.url, key: texRef.key })
-            .then((texture) => {
+          promises.push(
+            loadRef<any>(refs, background.texture, resourceManager, "scene.background.texture").then((texture) => {
               scene.background.texture = texture;
-            });
-          promises.push(backgroundPromise);
+            })
+          );
           scene.background.textureFillMode = background.textureFillMode ?? scene.background.textureFillMode;
         }
         break;
@@ -148,8 +144,7 @@ export function applySceneData(
   }
 
   // Post Process
-  const postProcessData = (sceneData as any).postProcess;
-  if (postProcessData) {
+  if (sceneData.postProcess) {
     Logger.warn("Post Process is not supported in scene yet, please add PostProcess component in entity instead.");
   }
 

--- a/packages/loader/src/SceneLoader.ts
+++ b/packages/loader/src/SceneLoader.ts
@@ -19,7 +19,7 @@ import { ParserContext, ParserType, SceneParser } from "./resource-deserialize";
 function loadRef<T>(refs: RefItem[], index: number, resourceManager: ResourceManager, label: string): Promise<T> {
   const ref = resolveRefItem(refs, index, "SceneLoader", label);
   // @ts-ignore
-  return resourceManager.getResourceByRef<T>({ $ref: ref.url, key: ref.key });
+  return resourceManager.getResourceByRef<T>(ref);
 }
 
 /**

--- a/packages/loader/src/SpriteLoader.ts
+++ b/packages/loader/src/SpriteLoader.ts
@@ -32,7 +32,7 @@ class SpriteLoader extends Loader<Sprite> {
     return (
       resourceManager
         // @ts-ignore
-        .getResourceByRef(data.belongToAtlas)
+        .getResourceByRef<SpriteAtlas>(data.belongToAtlas)
         .then((atlas: SpriteAtlas) => {
           return atlas.getSprite(data.fullPath) || this._loadFromTexture(resourceManager, data);
         })
@@ -44,7 +44,7 @@ class SpriteLoader extends Loader<Sprite> {
       return (
         resourceManager
           // @ts-ignore
-          .getResourceByRef(data.texture)
+          .getResourceByRef<Texture2D>(data.texture)
           .then((texture: Texture2D) => {
             const sprite = new Sprite(resourceManager.engine, texture, data.region, data.pivot, data.border);
             const { width, height } = data;

--- a/packages/loader/src/gltf/extensions/GLTFExtensionSchema.ts
+++ b/packages/loader/src/gltf/extensions/GLTFExtensionSchema.ts
@@ -1,5 +1,5 @@
 import type { IMaterialNormalTextureInfo, ITextureInfo } from "../GLTFSchema";
-import type { AssetRef } from "../../schema/CommonSchema";
+import type { RefItem } from "../../schema/CommonSchema";
 
 /**
  * Interfaces from the KHR_lights_punctual extension
@@ -153,7 +153,7 @@ export interface IEXTMeshoptCompressionSchema {
   filter?: "NONE" | "OCTAHEDRAL" | "QUATERNION" | "EXPONENTIAL";
 }
 
-export interface IGalaceanMaterialRemap extends AssetRef {
+export interface IGalaceanMaterialRemap extends RefItem {
   isClone?: boolean;
 }
 

--- a/packages/loader/src/prefab/PrefabParser.ts
+++ b/packages/loader/src/prefab/PrefabParser.ts
@@ -32,7 +32,7 @@ export class PrefabParser extends HierarchyParser<PrefabResource, ParserContext>
   }
 
   protected override _handleRootEntity(index: number): void {
-    this.prefabResource._root = this.context.entityMap.get(index);
+    this.prefabResource._root = this.context.entityInstances[index];
   }
 
   protected override _clearAndResolve(): PrefabResource {

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -68,7 +68,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
   private _parseEntities(): Promise<unknown> {
     const entities = this.data.entities;
-    const entityMap = this.context.entityMap;
+    const entityInstances = this.context.entityInstances;
     const engine = this._engine;
     const promises: Promise<void>[] = [];
 
@@ -78,14 +78,14 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       if (HierarchyParser._isPrefabInstanceEntity(entityConfig)) {
         promises.push(
           this._loadPrefabInstance(entityConfig, engine).then((entity) => {
-            entityMap.set(i, entity);
+            entityInstances[i] = entity;
           })
         );
       } else {
         const entity = new Entity(engine, entityConfig.name);
         HierarchyParser._applyEntityProps(entity, entityConfig);
         this._onEntityCreated(entity);
-        entityMap.set(i, entity);
+        entityInstances[i] = entity;
       }
     }
 
@@ -98,7 +98,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
   private _organizeEntities(): void {
     const entities = this.data.entities;
-    const entityMap = this.context.entityMap;
+    const entityInstances = this.context.entityInstances;
 
     for (let i = 0, n = entities.length; i < n; i++) {
       const entityConfig = entities[i];
@@ -108,9 +108,9 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       const children = entityConfig.children;
       if (!children) continue;
 
-      const parent = entityMap.get(i);
+      const parent = entityInstances[i];
       for (let j = 0, m = children.length; j < m; j++) {
-        parent.addChild(entityMap.get(children[j]));
+        parent.addChild(entityInstances[children[j]]);
       }
     }
 
@@ -127,22 +127,22 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   private _parseComponents(): void {
     const entities = this.data.entities;
     const allComponents = this.data.components;
-    const entityMap = this.context.entityMap;
-    const componentPairs = this.context.componentPairs;
+    const entityInstances = this.context.entityInstances;
+    const pendingComponents = this.context.pendingComponents;
     const refs = this.data.refs;
 
     for (let i = 0, n = entities.length; i < n; i++) {
       const entityConfig = entities[i];
       if (HierarchyParser._isPrefabInstanceEntity(entityConfig)) continue;
 
-      const entity = entityMap.get(i);
+      const entity = entityInstances[i];
       const componentIndices = entityConfig.components;
       if (!componentIndices) continue;
 
       for (let j = 0, m = componentIndices.length; j < m; j++) {
         const config = allComponents[componentIndices[j]];
-        const component = HierarchyParser._addComponentFromConfig(entity, config, refs);
-        componentPairs.push({ component, config });
+        const instance = HierarchyParser._addComponentFromConfig(entity, config, refs);
+        pendingComponents.push({ instance, config });
       }
     }
   }
@@ -152,13 +152,13 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   // ---------------------------------------------------------------------------
 
   private _parseComponentsPropsAndCalls(): Promise<unknown> {
-    const { componentPairs } = this.context;
+    const { pendingComponents } = this.context;
     const reflectionParser = this._reflectionParser;
     const promises: Promise<unknown>[] = [];
 
-    for (let i = 0, n = componentPairs.length; i < n; i++) {
-      const { component, config } = componentPairs[i];
-      promises.push(reflectionParser.parseMutationBlock(component, config));
+    for (let i = 0, n = pendingComponents.length; i < n; i++) {
+      const { instance, config } = pendingComponents[i];
+      promises.push(reflectionParser.parseMutationBlock(instance, config));
     }
 
     return Promise.all(promises);
@@ -170,7 +170,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
   private _parsePrefabOverrides(): Promise<unknown> {
     const entities = this.data.entities;
-    const entityMap = this.context.entityMap;
+    const entityInstances = this.context.entityInstances;
     const promises: Promise<unknown>[] = [];
 
     for (let i = 0, n = entities.length; i < n; i++) {
@@ -180,7 +180,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       const overrides = entityConfig.instance.overrides;
       if (!overrides) continue;
 
-      this._applyOverrides(entityMap.get(i), overrides, promises);
+      this._applyOverrides(entityInstances[i], overrides, promises);
     }
 
     return Promise.all(promises);
@@ -271,13 +271,12 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     return (
       engine.resourceManager
         // @ts-ignore
-        .getResourceByRef<Entity>({ $ref: refItem.url, key: refItem.key })
+        .getResourceByRef<Entity>(refItem)
         .then((prefabResource: PrefabResource | GLTFResource) => {
           const entity =
             prefabResource instanceof PrefabResource
               ? prefabResource.instantiate()
               : prefabResource.instantiateSceneRoot();
-
           this._onEntityCreated(entity);
           return entity;
         })

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -9,7 +9,6 @@ import {
   type EntityPropOverride,
   type EntityOverrideProps,
   type EntitySchema,
-  type InlineEntitySchema,
   type InstanceOverrides,
   type PrefabInstanceEntitySchema
 } from "../../../schema/HierarchySchema";
@@ -208,21 +207,25 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       }
     }
 
-    // addedComponents — new components on existing prefab entities
+    // addedComponents — attach top-level components[index] to a prefab entity and parse props
     if (overrides.addedComponents) {
+      const allComponents = this.data.components;
       for (let j = 0, m = overrides.addedComponents.length; j < m; j++) {
         const added = overrides.addedComponents[j];
         const entity = HierarchyParser._resolveEntity(rootEntity, added.target);
-        const component = HierarchyParser._addComponentFromConfig(entity, added.component, refs);
-        promises.push(reflectionParser.parseMutationBlock(component, added.component));
+        const config = allComponents[added.component];
+        const component = HierarchyParser._addComponentFromConfig(entity, config, refs);
+        promises.push(reflectionParser.parseMutationBlock(component, config));
       }
     }
 
-    // addedEntities — new child entities in prefab tree
+    // addedEntities — attach already-created top-level entityInstances[index] as a child
     if (overrides.addedEntities) {
+      const entityInstances = this.context.entityInstances;
       for (let j = 0, m = overrides.addedEntities.length; j < m; j++) {
         const added = overrides.addedEntities[j];
-        this._createInlineEntity(added.entity, HierarchyParser._resolveEntity(rootEntity, added.parent), promises);
+        const parent = HierarchyParser._resolveEntity(rootEntity, added.parent);
+        parent.addChild(entityInstances[added.entity]);
       }
     }
 
@@ -281,31 +284,6 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
           return entity;
         })
     );
-  }
-
-  // ---------------------------------------------------------------------------
-  // Inline entity creation (for addedEntities overrides)
-  // ---------------------------------------------------------------------------
-
-  private _createInlineEntity(config: InlineEntitySchema, parent: Entity, promises: Promise<unknown>[]): void {
-    const entity = new Entity(this._engine, config.name);
-    HierarchyParser._applyEntityProps(entity, config);
-    this._onEntityCreated(entity);
-    parent.addChild(entity);
-
-    if (config.components) {
-      for (let i = 0, n = config.components.length; i < n; i++) {
-        const compConfig = config.components[i];
-        const component = HierarchyParser._addComponentFromConfig(entity, compConfig, this.data.refs);
-        promises.push(this._reflectionParser.parseMutationBlock(component, compConfig));
-      }
-    }
-
-    if (config.children) {
-      for (let i = 0, n = config.children.length; i < n; i++) {
-        this._createInlineEntity(config.children[i], entity, promises);
-      }
-    }
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/HierarchyParser.ts
@@ -10,6 +10,7 @@ import {
   type EntityOverrideProps,
   type EntitySchema,
   type InlineEntitySchema,
+  type InstanceOverrides,
   type PrefabInstanceEntitySchema
 } from "../../../schema/HierarchySchema";
 import type { RefItem } from "../../../schema/CommonSchema";
@@ -65,7 +66,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   // Stage 1: Create entity instances
   // ---------------------------------------------------------------------------
 
-  private _parseEntities(): Promise<void> {
+  private _parseEntities(): Promise<unknown> {
     const entities = this.data.entities;
     const entityMap = this.context.entityMap;
     const engine = this._engine;
@@ -88,7 +89,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
       }
     }
 
-    return Promise.all(promises) as any;
+    return Promise.all(promises);
   }
 
   // ---------------------------------------------------------------------------
@@ -128,6 +129,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
     const allComponents = this.data.components;
     const entityMap = this.context.entityMap;
     const componentPairs = this.context.componentPairs;
+    const refs = this.data.refs;
 
     for (let i = 0, n = entities.length; i < n; i++) {
       const entityConfig = entities[i];
@@ -139,7 +141,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
       for (let j = 0, m = componentIndices.length; j < m; j++) {
         const config = allComponents[componentIndices[j]];
-        const component = HierarchyParser._addComponentFromConfig(entity, config, this.data.refs);
+        const component = HierarchyParser._addComponentFromConfig(entity, config, refs);
         componentPairs.push({ component, config });
       }
     }
@@ -149,104 +151,108 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   // Stage 4: Apply props and execute calls on components
   // ---------------------------------------------------------------------------
 
-  private _parseComponentsPropsAndCalls(): Promise<void> {
+  private _parseComponentsPropsAndCalls(): Promise<unknown> {
     const { componentPairs } = this.context;
     const reflectionParser = this._reflectionParser;
-    const promises: Promise<any>[] = [];
+    const promises: Promise<unknown>[] = [];
 
     for (let i = 0, n = componentPairs.length; i < n; i++) {
       const { component, config } = componentPairs[i];
       promises.push(reflectionParser.parseMutationBlock(component, config));
     }
 
-    return Promise.all(promises) as any;
+    return Promise.all(promises);
   }
 
   // ---------------------------------------------------------------------------
   // Stage 5: Apply prefab instance overrides
   // ---------------------------------------------------------------------------
 
-  private _parsePrefabOverrides(): Promise<void> {
+  private _parsePrefabOverrides(): Promise<unknown> {
     const entities = this.data.entities;
     const entityMap = this.context.entityMap;
-    const promises: Promise<any>[] = [];
+    const promises: Promise<unknown>[] = [];
 
     for (let i = 0, n = entities.length; i < n; i++) {
       const entityConfig = entities[i];
       if (!HierarchyParser._isPrefabInstanceEntity(entityConfig)) continue;
 
-      const instance = entityConfig.instance;
-      if (!instance.overrides) continue;
+      const overrides = entityConfig.instance.overrides;
+      if (!overrides) continue;
 
-      const rootEntity = entityMap.get(i);
-      const overrides = instance.overrides;
+      this._applyOverrides(entityMap.get(i), overrides, promises);
+    }
 
-      // entityProps — entity-level property overrides
-      if (overrides.entityProps) {
-        for (let j = 0, m = overrides.entityProps.length; j < m; j++) {
-          const override = overrides.entityProps[j] as EntityPropOverride;
-          HierarchyParser._applyEntityProps(HierarchyParser._resolveEntity(rootEntity, override.path), override);
-        }
-      }
+    return Promise.all(promises);
+  }
 
-      // componentProps — component-level property overrides
-      if (overrides.componentProps) {
-        for (let j = 0, m = overrides.componentProps.length; j < m; j++) {
-          const override = overrides.componentProps[j] as ComponentOverride;
-          const entity = HierarchyParser._resolveEntity(rootEntity, override.path);
-          const target = HierarchyParser._resolveComponent(entity, override.selector);
-          promises.push(this._reflectionParser.parseMutationBlock(target, override));
-        }
-      }
+  private _applyOverrides(rootEntity: Entity, overrides: InstanceOverrides, promises: Promise<unknown>[]): void {
+    const refs = this.data.refs;
+    const reflectionParser = this._reflectionParser;
 
-      // addedComponents — new components on existing prefab entities
-      if (overrides.addedComponents) {
-        for (let j = 0, m = overrides.addedComponents.length; j < m; j++) {
-          const added = overrides.addedComponents[j];
-          const entity = HierarchyParser._resolveEntity(rootEntity, added.target);
-          const component = HierarchyParser._addComponentFromConfig(entity, added.component, this.data.refs);
-          promises.push(this._reflectionParser.parseMutationBlock(component, added.component));
-        }
-      }
-
-      // addedEntities — new child entities in prefab tree
-      if (overrides.addedEntities) {
-        for (let j = 0, m = overrides.addedEntities.length; j < m; j++) {
-          const added = overrides.addedEntities[j];
-          this._createInlineEntity(added.entity, HierarchyParser._resolveEntity(rootEntity, added.parent), promises);
-        }
-      }
-
-      // removedEntities — pre-resolve all targets then destroy (destroy shifts sibling indices)
-      if (overrides.removedEntities) {
-        const removed = overrides.removedEntities;
-        const targets = new Array<Entity>(removed.length);
-        for (let j = 0, m = removed.length; j < m; j++) {
-          targets[j] = HierarchyParser._resolveEntity(rootEntity, removed[j]);
-        }
-        for (let j = 0, m = targets.length; j < m; j++) {
-          targets[j].destroy();
-        }
-      }
-
-      // removedComponents — pre-resolve all targets then destroy (destroy shifts component indices)
-      if (overrides.removedComponents) {
-        const targets: Component[] = [];
-        for (let j = 0, m = overrides.removedComponents.length; j < m; j++) {
-          const override = overrides.removedComponents[j];
-          const entity = HierarchyParser._resolveEntity(rootEntity, override.path);
-          const selectors = override.selectors;
-          for (let k = 0, p = selectors.length; k < p; k++) {
-            targets.push(HierarchyParser._resolveComponent(entity, selectors[k]));
-          }
-        }
-        for (let j = 0, m = targets.length; j < m; j++) {
-          targets[j].destroy();
-        }
+    // entityProps — entity-level property overrides
+    if (overrides.entityProps) {
+      for (let j = 0, m = overrides.entityProps.length; j < m; j++) {
+        const override = overrides.entityProps[j] as EntityPropOverride;
+        HierarchyParser._applyEntityProps(HierarchyParser._resolveEntity(rootEntity, override.path), override);
       }
     }
 
-    return Promise.all(promises) as any;
+    // componentProps — component-level property overrides
+    if (overrides.componentProps) {
+      for (let j = 0, m = overrides.componentProps.length; j < m; j++) {
+        const override = overrides.componentProps[j] as ComponentOverride;
+        const entity = HierarchyParser._resolveEntity(rootEntity, override.path);
+        const target = HierarchyParser._resolveComponent(entity, override.selector);
+        promises.push(reflectionParser.parseMutationBlock(target, override));
+      }
+    }
+
+    // addedComponents — new components on existing prefab entities
+    if (overrides.addedComponents) {
+      for (let j = 0, m = overrides.addedComponents.length; j < m; j++) {
+        const added = overrides.addedComponents[j];
+        const entity = HierarchyParser._resolveEntity(rootEntity, added.target);
+        const component = HierarchyParser._addComponentFromConfig(entity, added.component, refs);
+        promises.push(reflectionParser.parseMutationBlock(component, added.component));
+      }
+    }
+
+    // addedEntities — new child entities in prefab tree
+    if (overrides.addedEntities) {
+      for (let j = 0, m = overrides.addedEntities.length; j < m; j++) {
+        const added = overrides.addedEntities[j];
+        this._createInlineEntity(added.entity, HierarchyParser._resolveEntity(rootEntity, added.parent), promises);
+      }
+    }
+
+    // removedEntities — pre-resolve all targets then destroy (destroy shifts sibling indices)
+    if (overrides.removedEntities) {
+      const removed = overrides.removedEntities;
+      const targets = new Array<Entity>(removed.length);
+      for (let j = 0, m = removed.length; j < m; j++) {
+        targets[j] = HierarchyParser._resolveEntity(rootEntity, removed[j]);
+      }
+      for (let j = 0, m = targets.length; j < m; j++) {
+        targets[j].destroy();
+      }
+    }
+
+    // removedComponents — pre-resolve all targets then destroy (destroy shifts component indices)
+    if (overrides.removedComponents) {
+      const targets: Component[] = [];
+      for (let j = 0, m = overrides.removedComponents.length; j < m; j++) {
+        const override = overrides.removedComponents[j];
+        const entity = HierarchyParser._resolveEntity(rootEntity, override.path);
+        const selectors = override.selectors;
+        for (let k = 0, p = selectors.length; k < p; k++) {
+          targets.push(HierarchyParser._resolveComponent(entity, selectors[k]));
+        }
+      }
+      for (let j = 0, m = targets.length; j < m; j++) {
+        targets[j].destroy();
+      }
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -282,7 +288,7 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
   // Inline entity creation (for addedEntities overrides)
   // ---------------------------------------------------------------------------
 
-  private _createInlineEntity(config: InlineEntitySchema, parent: Entity, promises: Promise<any>[]): void {
+  private _createInlineEntity(config: InlineEntitySchema, parent: Entity, promises: Promise<unknown>[]): void {
     const entity = new Entity(this._engine, config.name);
     HierarchyParser._applyEntityProps(entity, config);
     this._onEntityCreated(entity);
@@ -334,9 +340,10 @@ export abstract class HierarchyParser<T extends Scene | PrefabResource, V extend
 
   /** Resolve component class from config and add to entity. Throws if class is not registered. */
   private static _addComponentFromConfig(entity: Entity, config: ComponentSchema, refs: RefItem[]): Component {
-    const key = config.script
-      ? resolveRefItem(refs, config.script.$ref, "HierarchyParser", "component.script").url
-      : config.type;
+    const key =
+      config.script != null
+        ? resolveRefItem(refs, config.script, "HierarchyParser", "component.script").url
+        : config.type;
     const Class = Loader.getClass(key);
     if (!Class) throw new Error(`Loader.getClass: class "${key}" is not registered`);
     return entity.addComponent(Class);

--- a/packages/loader/src/resource-deserialize/resources/parser/ParserContext.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ParserContext.ts
@@ -17,7 +17,6 @@ export class ParserContext {
 
   readonly resourceManager: ResourceManager;
 
-  private _tasks: Set<string> = new Set();
   private _loaded: number = 0;
   private _total: number = 0;
 
@@ -38,11 +37,8 @@ export class ParserContext {
   _setTaskCompleteProgress: (loaded: number, total: number) => void;
 
   /** @internal */
-  _addDependentAsset(url: string, promise: AssetPromise<any>): void {
-    const tasks = this._tasks;
-    if (tasks.has(url)) return;
+  _addDependentAsset(promise: AssetPromise<any>): void {
     ++this._total;
-    tasks.add(url);
     promise.finally(() => {
       ++this._loaded;
       this._setTaskCompleteProgress(this._loaded, this._total);

--- a/packages/loader/src/resource-deserialize/resources/parser/ParserContext.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ParserContext.ts
@@ -10,10 +10,10 @@ export enum ParserType {
  * @internal
  */
 export class ParserContext {
-  /** Flat entity index → Entity instance */
-  entityMap: Map<number, Entity> = new Map();
-  /** Component instance → config pairs for props application */
-  componentPairs: Array<{ component: Component; config: ComponentSchema }> = [];
+  /** Runtime Entity instances, indexed by the flat entities[] position. */
+  entityInstances: Entity[] = [];
+  /** Components waiting for props/calls application (Stage 4). */
+  pendingComponents: Array<{ instance: Component; config: ComponentSchema }> = [];
 
   readonly resourceManager: ResourceManager;
 
@@ -30,8 +30,8 @@ export class ParserContext {
   }
 
   clear() {
-    this.entityMap.clear();
-    this.componentPairs.length = 0;
+    this.entityInstances.length = 0;
+    this.pendingComponents.length = 0;
   }
 
   /** @internal */

--- a/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/parser/ReflectionParser.ts
@@ -99,7 +99,7 @@ export class ReflectionParser {
         return Promise.reject(error);
       }
       // @ts-ignore
-      return context.resourceManager.getResourceByRef({ $ref: refItem.url, key: refItem.key }).then((resource) => {
+      return context.resourceManager.getResourceByRef(refItem).then((resource) => {
         if (resource && context.type === ParserType.Prefab) {
           // @ts-ignore
           context.resource._addDependenceAsset(resource);
@@ -178,7 +178,7 @@ export class ReflectionParser {
 
   private _resolveEntityRef(path: number[]): Entity | null {
     if (!path || path.length === 0) return null;
-    let entity = this._context.entityMap.get(path[0]) ?? null;
+    let entity = this._context.entityInstances[path[0]] ?? null;
     for (let i = 1, n = path.length; entity && i < n; i++) {
       entity = entity.children[path[i]] ?? null;
     }

--- a/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
@@ -21,9 +21,8 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext> {
     const resourceManager = context.resourceManager;
     const refs = data.refs;
     for (let i = 0, n = refs.length; i < n; i++) {
-      const ref = refs[i];
       // @ts-ignore
-      context._addDependentAsset(ref.url, resourceManager.getResourceByRef(ref));
+      context._addDependentAsset(resourceManager.getResourceByRef(refs[i]));
     }
   }
 

--- a/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
@@ -23,7 +23,7 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext> {
     for (let i = 0, n = refs.length; i < n; i++) {
       const ref = refs[i];
       // @ts-ignore
-      context._addDependentAsset(ref.url, resourceManager.getResourceByRef({ $ref: ref.url, key: ref.key }));
+      context._addDependentAsset(ref.url, resourceManager.getResourceByRef(ref));
     }
   }
 
@@ -32,7 +32,7 @@ export class SceneParser extends HierarchyParser<Scene, ParserContext> {
   }
 
   protected override _handleRootEntity(index: number): void {
-    this.scene.addRootEntity(this.context.entityMap.get(index));
+    this.scene.addRootEntity(this.context.entityInstances[index]);
   }
 
   protected override _clearAndResolve() {

--- a/packages/loader/src/schema/CommonSchema.ts
+++ b/packages/loader/src/schema/CommonSchema.ts
@@ -6,10 +6,6 @@ export interface RefItem {
   key?: string;
 }
 
-export interface AssetRef {
-  $ref: number;
-}
-
 /** path[0] = flat index into top-level entities[]; subsequent indices descend via children. */
 export type EntityRef = number[];
 

--- a/packages/loader/src/schema/HierarchySchema.ts
+++ b/packages/loader/src/schema/HierarchySchema.ts
@@ -14,21 +14,18 @@ export interface EntityOverrideProps {
   scale?: Vec3Tuple;
 }
 
-export interface InlineEntitySchema extends EntityOverrideProps {
-  children?: InlineEntitySchema[];
-  components?: ComponentSchema[];
-}
-
 export interface AddedEntityOverride {
   /** Parent path from prefab instance root via children indices. `[]` = instance root. */
   parent: number[];
-  entity: InlineEntitySchema;
+  /** Index into the top-level entities[] array. */
+  entity: number;
 }
 
 export interface AddedComponentOverride {
   /** Target entity path from prefab instance root via children indices. `[]` = instance root. */
   target: number[];
-  component: ComponentSchema;
+  /** Index into the top-level components[] array. */
+  component: number;
 }
 
 export interface EntityPropOverride extends EntityOverrideProps {

--- a/packages/loader/src/schema/HierarchySchema.ts
+++ b/packages/loader/src/schema/HierarchySchema.ts
@@ -1,8 +1,8 @@
-import type { AssetRef, MutationBlock, RefItem, Vec3Tuple } from "./CommonSchema";
+import type { MutationBlock, RefItem, Vec3Tuple } from "./CommonSchema";
 
 export interface ComponentSchema extends MutationBlock {
   type: string;
-  script?: AssetRef;
+  script?: number;
 }
 
 export interface EntityOverrideProps {
@@ -71,7 +71,6 @@ export interface InstanceSchema {
 export interface NormalEntitySchema extends EntityOverrideProps {
   children?: number[];
   components?: number[];
-  instance?: undefined;
 }
 
 export interface PrefabInstanceEntitySchema {

--- a/packages/loader/src/schema/MaterialSchema.ts
+++ b/packages/loader/src/schema/MaterialSchema.ts
@@ -7,7 +7,7 @@ import {
   RenderQueueType,
   StencilOperation
 } from "@galacean/engine-core";
-import type { AssetRef } from "./CommonSchema";
+import type { RefItem } from "./CommonSchema";
 import type { IColor, IVector2, IVector3 } from "./BasicSchema";
 
 export interface IRenderState {
@@ -58,12 +58,12 @@ export interface IMaterialSchema {
   shaderData: {
     [key: string]: {
       type: MaterialLoaderType;
-      value: IVector3 | IVector2 | IColor | number | AssetRef;
+      value: IVector3 | IVector2 | IColor | number | RefItem;
     };
   };
   macros: Array<{ name: string; value?: string }>;
   renderState: IRenderState;
-  shaderRef: AssetRef;
+  shaderRef: RefItem;
 }
 
 export enum MaterialLoaderType {

--- a/packages/loader/src/schema/SceneSchema.ts
+++ b/packages/loader/src/schema/SceneSchema.ts
@@ -62,5 +62,7 @@ export interface SceneFile extends HierarchyFile {
       bilateralThreshold?: number;
       minHorizonAngle?: number;
     };
+    /** Not supported in scene yet; presence triggers a warning. */
+    postProcess?: unknown;
   };
 }

--- a/tests/src/loader/PrefabResource.test.ts
+++ b/tests/src/loader/PrefabResource.test.ts
@@ -347,21 +347,18 @@ describe("Prefab instance overrides", () => {
           instance: {
             asset: 0,
             overrides: {
-              addedComponents: [
-                {
-                  target: [],
-                  component: {
-                    type: "OverrideCallScript",
-                    props: { value: "base" },
-                    calls: [{ method: "appendSuffix", args: ["-added"] }]
-                  }
-                }
-              ]
+              addedComponents: [{ target: [], component: 0 }]
             }
           }
         }
       ],
-      components: [],
+      components: [
+        {
+          type: "OverrideCallScript",
+          props: { value: "base" },
+          calls: [{ method: "appendSuffix", args: ["-added"] }]
+        }
+      ],
       root: 0
     };
 
@@ -399,27 +396,23 @@ describe("Prefab instance overrides", () => {
           instance: {
             asset: 0,
             overrides: {
-              addedEntities: [
-                {
-                  parent: [] as number[],
-                  entity: {
-                    name: "addedChild",
-                    position: [1, 2, 3] as [number, number, number],
-                    components: [
-                      {
-                        type: "OverrideCallScript",
-                        props: { value: "base" },
-                        calls: [{ method: "appendSuffix", args: ["-inline"] }]
-                      }
-                    ]
-                  }
-                }
-              ]
+              addedEntities: [{ parent: [] as number[], entity: 2 }]
             }
           }
+        },
+        {
+          name: "addedChild",
+          position: [1, 2, 3] as [number, number, number],
+          components: [0]
         }
       ],
-      components: [],
+      components: [
+        {
+          type: "OverrideCallScript",
+          props: { value: "base" },
+          calls: [{ method: "appendSuffix", args: ["-inline"] }]
+        }
+      ],
       root: 0
     };
 

--- a/tests/src/loader/SceneFormatV2.test.ts
+++ b/tests/src/loader/SceneFormatV2.test.ts
@@ -142,8 +142,8 @@ describe("ReflectionParser v2 props resolution", () => {
     const context = new ParserContext(engine, ParserType.Scene, scene);
     const entity0 = new Entity(engine, "entity0");
     const entity1 = new Entity(engine, "entity1");
-    context.entityMap.set(0, entity0);
-    context.entityMap.set(1, entity1);
+    context.entityInstances[0] = entity0;
+    context.entityInstances[1] = entity1;
 
     const parser = new ReflectionParser(context, []);
     const target: any = {};
@@ -172,7 +172,7 @@ describe("ReflectionParser v2 props resolution", () => {
     const grandchild = new Entity(engine, "grandchild");
     root.addChild(child);
     child.addChild(grandchild);
-    context.entityMap.set(0, root);
+    context.entityInstances[0] = root;
 
     const parser = new ReflectionParser(context, []);
     const target: any = {};
@@ -190,7 +190,7 @@ describe("ReflectionParser v2 props resolution", () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
     const root = new Entity(engine, "root");
-    context.entityMap.set(0, root);
+    context.entityInstances[0] = root;
 
     const parser = new ReflectionParser(context, []);
     const target: any = {};
@@ -217,7 +217,7 @@ describe("ReflectionParser v2 props resolution", () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
     const entity = new Entity(engine, "test");
-    context.entityMap.set(0, entity);
+    context.entityInstances[0] = entity;
 
     const parser = new ReflectionParser(context, []);
     const target: any = {};
@@ -237,7 +237,7 @@ describe("ReflectionParser calls resolution", () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
     const entity = new Entity(engine, "target");
-    context.entityMap.set(1, entity);
+    context.entityInstances[1] = entity;
 
     const asset = { name: "call-asset" };
     const getResourceByRef = vi
@@ -571,7 +571,7 @@ describe("SceneParser v2 entity tree", () => {
       .spyOn(engine.resourceManager as any, "getResourceByRef")
       .mockResolvedValue({ _addReferCount() {} } as any);
 
-    let collectedRefs: Array<{ $ref: string; key?: string }>;
+    let collectedRefs: Array<{ url: string; key?: string }>;
     try {
       parser._collectDependentAssets(data);
       collectedRefs = getResourceByRef.mock.calls.map((args) => args[0] as any);
@@ -579,7 +579,7 @@ describe("SceneParser v2 entity tree", () => {
       getResourceByRef.mockRestore();
     }
     expect(collectedRefs).to.have.length(4);
-    expect(collectedRefs.map((r) => r.$ref)).to.deep.equal([
+    expect(collectedRefs.map((r) => r.url)).to.deep.equal([
       "nested.prefab",
       "component-call.mat",
       "override-call.mat",
@@ -599,8 +599,8 @@ describe("ReflectionParser $signal resolution", () => {
     const context = new ParserContext(engine, ParserType.Scene, scene);
     const entity0 = new Entity(engine, "source");
     const entity1 = new Entity(engine, "target");
-    context.entityMap.set(0, entity0);
-    context.entityMap.set(1, entity1);
+    context.entityInstances[0] = entity0;
+    context.entityInstances[1] = entity1;
 
     const parser = new ReflectionParser(context, []);
 
@@ -630,7 +630,7 @@ describe("ReflectionParser $signal resolution", () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
     const entity0 = new Entity(engine, "source");
-    context.entityMap.set(0, entity0);
+    context.entityInstances[0] = entity0;
     // entity 1 does NOT exist in entityMap
 
     const parser = new ReflectionParser(context, []);
@@ -659,8 +659,8 @@ describe("ReflectionParser $signal resolution", () => {
     const context = new ParserContext(engine, ParserType.Scene, scene);
     const entity0 = new Entity(engine, "source");
     const entity1 = new Entity(engine, "target");
-    context.entityMap.set(0, entity0);
-    context.entityMap.set(1, entity1);
+    context.entityInstances[0] = entity0;
+    context.entityInstances[1] = entity1;
 
     const parser = new ReflectionParser(context, []);
 
@@ -679,7 +679,7 @@ describe("ReflectionParser $signal resolution", () => {
     const scene = new Scene(engine);
     const context = new ParserContext(engine, ParserType.Scene, scene);
     const entity = new Entity(engine, "test");
-    context.entityMap.set(0, entity);
+    context.entityInstances[0] = entity;
 
     const parser = new ReflectionParser(context, []);
     const target: any = {};
@@ -750,7 +750,7 @@ describe("applySceneData scene property parsing", () => {
     const getResourceByRef = vi
       .spyOn(engine.resourceManager as any, "getResourceByRef")
       .mockImplementation((ref: any) => {
-        switch (ref.$ref) {
+        switch (ref.url) {
           case "custom-ambient":
             return Promise.resolve({ specularTexture: customAmbientTexture }) as any;
           case "ambient-light":
@@ -798,7 +798,7 @@ describe("applySceneData scene property parsing", () => {
     const getResourceByRef = vi
       .spyOn(engine.resourceManager as any, "getResourceByRef")
       .mockImplementation((ref: any) => {
-        switch (ref.$ref) {
+        switch (ref.url) {
           case "sky-mesh":
             return Promise.resolve(skyMesh) as any;
           case "sky-material":
@@ -838,7 +838,7 @@ describe("applySceneData scene property parsing", () => {
     const getResourceByRef = vi
       .spyOn(engine.resourceManager as any, "getResourceByRef")
       .mockImplementation((ref: any) => {
-        if (ref.$ref === "background-texture") {
+        if (ref.url === "background-texture") {
           return Promise.resolve(backgroundTexture) as any;
         }
         return Promise.resolve(null) as any;


### PR DESCRIPTION
针对 PR #2959 的 review 建议,在 `refactor/scene-format-v2` 基础上做的优化。核心原则:**不为省代码而省**——只保留让代码更合理的改动。

## Schema（协议层）

- **`ComponentSchema.script: AssetRef → number`** — 对齐其他结构位置的 refs 索引字段（`instance.asset`、`background.texture`、`ambient.ambientLight` 都是裸 number）。原协议中 `script` 是唯一用 `{ $ref }` 包装的结构字段,不一致。
- **删除 `NormalEntitySchema.instance?: undefined`** — JSON 永不出现的 TS discriminated union hack,污染 schema 文档。运行时判别已走 `"instance" in entityConfig`。
- **`SceneSchema` 声明 `postProcess?: unknown`** — 消除 `(sceneData as any).postProcess`。
- **`AssetRef` 删除,统一为 `RefItem { url, key? }`** — 原 `AssetRef { $ref: number }` 类型定义和实际运行时数据不符（实际是 `{ $ref: string, key? }` 形态）,是历史误命名。现在 API 和 schema 统一用 `RefItem`。
- **`addedEntities[].entity` / `addedComponents[].component` 从内联对象改为顶层索引** — 原协议里 override 的追加字段是 `InlineEntitySchema` / `ComponentSchema` 完整对象,追加对象无法被 `$entity` / `$component` 跨引用。新协议下追加对象进入顶层 `entities[]` / `components[]`,override 只存数字索引。收益:
  - 追加对象可被脚本用 `$entity: [index]` 引用（典型场景:scene 里的 CameraFollow 引用追加到 Player prefab 上的 Weapon）
  - 协议表达彻底一致（所有 entity/component 对象都在顶层数组,引用统一用索引）
  - 删除 `InlineEntitySchema` 类型和 `_createInlineEntity` 递归方法

## ResourceManager API

- **`getResourceByRef` 参数字段 `$ref → url`** — 原字段名 `$ref: string` 装的是 URL 字符串,和 schema 的 `{ $ref: number }` 语义冲突、消除调用点的 `@ts-ignore` 字段名误命名。字段名和值语义对齐。

## Parser（职责分离 + 命名）

- **抽出 `_applyOverrides` 方法** — 原 `_parsePrefabOverrides` 80+ 行承担两件事（迭代 prefab instance + 应用 6 种 override）。抽完后主函数职责收敛为"找 prefab instance + 调度",子方法负责"应用 overrides"。
- **`componentPairs → pendingComponents`**、元素字段 `component → instance` — 命名准确表达"等待初始化的组件"。
- **删除 `ParserContext._tasks` URL 去重** — `_addDependentAsset` 只在 `_collectDependentAssets` 被调用一次 per RefItem,refs[] 编辑器侧已去重,`tasks.has(url)` 永不返回 true。死代码。

## 性能优化

- **`entityMap: Map<number, Entity> → entityInstances: Entity[]`** — key 本就是 `0..n-1` 连续整数,Map 是过度通用化。数组下标访问跳过函数调用 + hash 查找,内存紧凑,V8 packed array 优化友好。scene 加载百千 entity 级规模下累计开销可观。
- **循环外缓存 `refs = this.data.refs`** — `_parseComponents` / `_parsePrefabOverrides` 内部循环多次访问 `this.data.refs`,缓存到局部变量避免每轮重复属性查找。
- **3 处 `Promise.all(promises) as any`** → 函数签名改 `Promise<unknown>`,零运行时开销消除类型断言（不引入额外 Promise / microtask）。相比 `.then(() => {})` 或 `async/await` 方案,这是性能最优解。

## 类型诚实化（消除 `any` / `as any`）

- 3 处 `Promise.all(promises) as any` → `Promise<unknown>` 返回类型
- `Promise<any>[]` → `Promise<unknown>[]` — 只 push 不读的 buffer,unknown 比 any 更严格
- `(sceneData as any).postProcess` → `sceneData.postProcess` — 配合 schema 声明

## SceneLoader（消除重复）

- **引入 `loadRef(refs, index, rm, label)` helper** — 消除 5 处重复的 `resolveRefItem + getResourceByRef + @ts-ignore` 三件套。

## 关于 `refs[]` 自描述的设计立场

PR #2959 的 review 中有建议"把依赖信息收归 project.json,scene/prefab 去掉 refs[]"（参考 Unity Addressables / Unreal AssetRegistry / Cocos config.json / PlayCanvas 等 registry 模式）。这里明确说明 **Galacean 的设计选择是自描述,不是 registry 模式**。

### 发布型 vs 生态型引擎

| 维度 | 发布型（Unity / Unreal / Cocos / PlayCanvas） | 生态型（Galacean） |
|---|---|---|
| 交付物 | 完整应用 | 单个资产文件 |
| scene 流通范围 | 永远在自己的 registry 体系内 | 跨项目流通 |
| 资产独立可用性 | ❌ 脱离 project 不可用 | ✅ 单文件闭包 |
| 生态策略 | 私有 | 资产库共享 |
| 合适模式 | registry | **自描述** |

### Galacean 的资产库场景

Galacean 的核心定位是**资产库**——不像 Unity 需要加载 bundle,应该能**纯粹地加载单个 scene 或 prefab**。真正的运行时跨项目复用,不依赖编辑器项目重新导入导出。

这正是 `refs[]` 自描述带来的能力:资产自带所有必要元数据,任何消费方拿到文件就能用。

registry 模式会关闭这扇门:
- 脱离 project.json 的 prefab 不能独立加载
- 资产库里每个资产要带一份 mini-registry → 本质又退回自描述
- 跨项目复用时必须拉上源项目的 project.json

### Registry 被援引的 4 个收益分析

|收益|Registry|Galacean 自描述|
|---|---|---|
|精确进度|✅ size 字段| `refs[]` 可补 size 字段|
|增量加载差集|✅| `_loadingPromises` 已在下载层去重|
|按需卸载引用计数|✅| **`ReferResource._refCount` 已完整实现**|
|Tree shaking|✅| build 期工具问题,runtime 协议无关|

**所以这不是"方向认可但以后再考虑"**——是 Galacean 的设计路线选择。自描述与"资产库独立使用"的定位一致,不应改成 registry 模式。

## 测试

87 个 loader tests 全部通过（1 skipped）。